### PR TITLE
fix: Itemstack Textures will now always be used over Shape textures

### DIFF
--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
@@ -38,15 +38,11 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
 
     void IAttachableToEntity.CollectTextures(ItemStack stack, Shape shape, string texturePrefixCode, Dictionary<string, CompositeTexture> intoDict)
     {
-        // Input Shape already has textures defined, as lowest priority
-
-        // Overwrite any Shape textures with those defined on the Item itself
         foreach ((string textureCode, CompositeTexture texture) in stack.Item.Textures)
         {
             shape.Textures[textureCode] = texture.Baked.BakedName;
         }
 
-        // Finally, overwrite with any textures defined in the Attributes as highest priority
         Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType = new();
 
         if (stack.Collectible is ItemShapeTexturesFromAttributes item)
@@ -59,8 +55,7 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(texturesByType, out Dictionary<string, CompositeTexture> _textures);
-        if (_textures != null)
+        if (variants.FindByVariant(texturesByType, out Dictionary<string, CompositeTexture> _textures))
         {
             foreach ((string textureCode, CompositeTexture texture) in _textures)
             {

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
@@ -38,6 +38,15 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
 
     void IAttachableToEntity.CollectTextures(ItemStack stack, Shape shape, string texturePrefixCode, Dictionary<string, CompositeTexture> intoDict)
     {
+        // Input Shape already has textures defined, as lowest priority
+
+        // Overwrite any Shape textures with those defined on the Item itself
+        foreach ((string textureCode, CompositeTexture texture) in stack.Item.Textures)
+        {
+            shape.Textures[textureCode] = texture.Baked.BakedName;
+        }
+
+        // Finally, overwrite with any textures defined in the Attributes as highest priority
         Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType = new();
 
         if (stack.Collectible is ItemShapeTexturesFromAttributes item)
@@ -51,15 +60,16 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
 
         Variants variants = Variants.FromStack(stack);
         variants.FindByVariant(texturesByType, out Dictionary<string, CompositeTexture> _textures);
-        _textures ??= (collObj as Item)?.Textures;
-
-        foreach ((string textureCode, CompositeTexture texture) in _textures)
+        if (_textures != null)
         {
-            CompositeTexture ctex = texture.Clone();
-            ctex = variants.ReplacePlaceholders(ctex);
-            ctex.Bake(api.Assets);
-            intoDict[textureCode] = ctex;
-            shape.Textures[textureCode] = ctex.Baked.BakedName;
+            foreach ((string textureCode, CompositeTexture texture) in _textures)
+            {
+                CompositeTexture ctex = texture.Clone();
+                ctex = variants.ReplacePlaceholders(ctex);
+                ctex.Bake(api.Assets);
+                intoDict[textureCode] = ctex;
+                shape.Textures[textureCode] = ctex.Baked.BakedName;
+            }
         }
     }
 

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
@@ -74,18 +74,14 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
             }
         }
 
-        // Sets up default textures from the Shape, as lowest priority
         UniversalShapeTextureSource stexSource = new UniversalShapeTextureSource(clientApi, targetAtlas, shape, rcshape.Base.ToString());
 
-        // Overwrite any Shape textures with those defined on the Item itself
         foreach ((string textureCode, CompositeTexture texture) in itemstack.Item.Textures)
         {
             stexSource.textures[textureCode] = texture;
         }
 
-        // Finally, overwrite with any textures defined in the Attributes as highest priority
-        variants.FindByVariant(texturesByType, out Dictionary<string, CompositeTexture> _textures);
-        if (_textures != null)
+        if (variants.FindByVariant(texturesByType, out Dictionary<string, CompositeTexture> _textures))
         {
             foreach ((string textureCode, CompositeTexture texture) in _textures)
             {


### PR DESCRIPTION
Fix for #1.

With this change, any lookup of textures will follow this priority, from lowest priority to highest:
1. Shape file
2. Itemtype file
3. Attributes

This should fix the bug where partial matches of attributes, where only some textures were defined, would then default back to the Shape file's textures.

This can mean that extra textures are defined beyond what the Shape actually needs. For example if the Itemtype file defines more textures because some other shape needs more textures than this smaller Shape we're actually using. In my testing, this doesn't seem to cause any problems, game seems to handle that without issue.