### PR TITLE
Fix: Shape Rendering was broken by Overlay support

### DIFF
--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
@@ -84,7 +84,7 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
             {
                 if (WildcardUtil.Match(_slotCode, slotCode))
                 {
-                    CompositeShape rcshape = variants.ReplacePlaceholders(cshape);
+                    CompositeShape rcshape = variants.ReplacePlaceholders(cshape.Clone());
                     return rcshape;
                 }
             }

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
@@ -56,7 +56,7 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
 
         if (_shape == null) return mesh;
 
-        CompositeShape rcshape = variants.ReplacePlaceholders(_shape);
+        CompositeShape rcshape = variants.ReplacePlaceholders(_shape.Clone());
         rcshape.Base.WithPathAppendixOnce(".json").WithPathPrefixOnce("shapes/");
 
         Shape shape = clientApi.Assets.TryGet(rcshape.Base)?.ToObject<Shape>();


### PR DESCRIPTION
# Description
Adding support for Overlays caused dynamic Shape choice via attribute to stop working.

This fixes that by re-adding the `.Clone()` statements to when we're replacing the placeholder for attribute shapes.

My understanding is that without `.Clone()`, it would do the placeholder replacement just once for whatever the first item was, then every other item would use the same already-replaced string.

# Testing
Tested using this medallion itemtype: 
[medallion.json](https://github.com/user-attachments/files/21433369/medallion.json)


Without this PR, on the latest version of the code, all medallions share the same shape. They're supposed to differ:
<img width="553" height="145" alt="Screenshot 2025-07-25 160830" src="https://github.com/user-attachments/assets/f9ba0885-4fd9-4268-aa1a-d66d1bc3363a" />


Then with the changes from this PR, the medallions start to work again and have different shapes:
<img width="551" height="140" alt="Screenshot 2025-07-25 160018" src="https://github.com/user-attachments/assets/f3299517-7e09-4722-8bfa-5dc9eb1f1199" />
