### PR TITLE
Fix overlay textures

### DIFF
--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -4,7 +4,7 @@
   "name": "Attribute Rendering Library",
   "authors": [ "Craluminum2413" ],
   "description": "To be added",
-  "version": "1.0.0-dev.14",
+  "version": "1.0.0-dev.15",
   "dependencies": {
     "game": ""
   }


### PR DESCRIPTION
#### Fixed
- Textures of parent shape now remain correct when overlays are defined
- Attribute-based textures stay mapped correctly when overlays are defined