### PR TITLE
suppress warnings when defined overlays do not exist

### DIFF
--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
@@ -80,7 +80,16 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
             {
                 if (WildcardUtil.Match(_slotCode, slotCode))
                 {
+                    List<CompositeShape> overlays = new();
                     CompositeShape rcshape = variants.ReplacePlaceholders(cshape.Clone());
+                    foreach (CompositeShape overlay in rcshape.Overlays)
+                    {
+                        if (api.Assets.Exists(overlay.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json")))
+                        {
+                            overlays.Add(overlay);
+                        }
+                    }
+                    rcshape.Overlays = overlays.ToArray();
                     return rcshape;
                 }
             }

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -4,7 +4,7 @@
     "name": "Attribute Rendering Library",
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "description": "Attribute-based variant system for rendering things.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "dependencies": {
         "game": "1.20.0"
     }


### PR DESCRIPTION
### Changes
- `CollectibleBehaviorAttachableToEntityTyped.GetAttachedShape` now removes nonexistent overlays

This makes it so the game doesn't spam warnings to the console if an overlay cannot be found, just like how the regular `CollectibleBehaviorShapeTexturesFromAttributes` does not show warnings.