### PR TITLE
Enable the use of full domain and path placeholders

### DIFF
--- a/AttributeRenderingLibrary/Utility/Variants.cs
+++ b/AttributeRenderingLibrary/Utility/Variants.cs
@@ -99,15 +99,31 @@ public class Variants
         return input;
     }
 
+    public AssetLocation ReplacePlaceholders(AssetLocation location)
+    {
+        if (location.Domain != "game")
+        {
+            location.Path = ReplacePlaceholders(location.Path);
+            return location;
+        }
+        location = new AssetLocation(ReplacePlaceholders(location.Path));
+        if (!location.HasDomain())
+        {
+            location.Domain = "game";
+        }
+
+        return location;
+    }
+
     public CompositeShape ReplacePlaceholders(CompositeShape cshape)
     {
-        cshape.Base.Path = ReplacePlaceholders(cshape.Base.Path);
+        cshape.Base = ReplacePlaceholders(cshape.Base);
 
         if (cshape.Overlays != null && cshape.Overlays.Length > 0)
         {
             for (int i = 0; i < cshape.Overlays.Length; i++)
             {
-                cshape.Overlays[i].Base.Path = ReplacePlaceholders(cshape.Overlays[i].Base.Path);
+                cshape.Overlays[i].Base = ReplacePlaceholders(cshape.Overlays[i].Base);
             }
         }
 


### PR DESCRIPTION
### Changes
- using full domain + path in placeholders is now possible

Example:
```json
"shape": {
  "metal-*": {
    "metaltexture": "{metal}"
  }
}
```
in combination with the following attribute: `mymetalmod:item/shiny/metal1`
The "metaltexture" used to resolve to `game:mymetalmod:item/shiny/metal1`, now it removes the `game` domain if another domain was found