### PR TITLE
Fixes crash when attached shape overlays is null

### DIFF
--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
@@ -80,8 +80,13 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
             {
                 if (WildcardUtil.Match(_slotCode, slotCode))
                 {
-                    List<CompositeShape> overlays = new();
                     CompositeShape rcshape = variants.ReplacePlaceholders(cshape.Clone());
+                    if (rcshape.Overlays == null || rcshape.Overlays.Length == 0)
+                    {
+                        return cshape;
+                    }
+
+                    List<CompositeShape> overlays = new();
                     foreach (CompositeShape overlay in rcshape.Overlays)
                     {
                         if (api.Assets.Exists(overlay.Base.Clone().WithPathPrefixOnce("shapes/").WithPathAppendixOnce(".json")))


### PR DESCRIPTION
### Fixes
- Fixes crash when shape overlays for entity attached shape is null