### PR TITLE
Suppress missing texture errors in log

### DIFF
--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorAttachableToEntityTyped.cs
@@ -51,12 +51,18 @@ public class CollectibleBehaviorAttachableToEntityTyped : CollectibleBehavior, I
         }
 
         Variants variants = Variants.FromStack(stack);
+        ICoreClientAPI capi = api as ICoreClientAPI;
         if (variants.FindByVariant(texturesByType, out Dictionary<string, CompositeTexture> _textures))
         {
             foreach ((string textureCode, CompositeTexture texture) in _textures)
             {
                 CompositeTexture ctex = texture.Clone();
                 ctex = variants.ReplacePlaceholders(ctex);
+                if (!api.Assets.Exists(ctex.Base.CopyWithPathPrefixAndAppendixOnce("textures/", ".png")))
+                {
+                    ctex.Base.Path = "unknown";
+                    ctex.Base.Domain = "game";
+                }
                 ctex.Bake(api.Assets);
                 intoDict[textureCode] = ctex;
                 shape.Textures[textureCode] = ctex.Baked.BakedName;

--- a/AttributeRenderingLibrary/Utility/ShapeOverlayHelper.cs
+++ b/AttributeRenderingLibrary/Utility/ShapeOverlayHelper.cs
@@ -78,6 +78,11 @@ public class ShapeOverlayHelper
         {
             CompositeTexture ctex = texture.Clone();
             ctex = variants.ReplacePlaceholders(ctex);
+            if (!clientApi.Assets.Exists(ctex.Base.CopyWithPathPrefixAndAppendixOnce("textures/", ".png")))
+            {
+                ctex.Base.Path = "unknown";
+                ctex.Base.Domain = "game";
+            }
             ctex.Bake(clientApi.Assets);
             if (prefixedTextureCodes != null && prefixedTextureCodes.ContainsKey(textureCode))
             {


### PR DESCRIPTION
### Changes
- Textures that fail to resolve are now replaced by the unknown texture, no longer generating warning in the console / log