### PR TITLE
Implement BlockBehavior and BlockEntityBehavior that store Variants in BlockEntity

### DIFF
--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorHorizontalAttachable.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorHorizontalAttachable.cs
@@ -1,0 +1,178 @@
+﻿using System.Collections.Generic;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+
+namespace AttributeRenderingLibrary;
+
+/// <summary>
+/// Version of <see cref="Vintagestory.GameContent.BlockBehaviorHorizontalAttachable"/> that works with <see cref="Variants"/>
+/// </summary>
+/// <param name="block"></param>
+public class BlockBehaviorHorizontalAttachable(Block block) : BlockBehavior(block)
+{
+    bool handleDrops = true;
+    string dropBlockFace = "north";
+    string dropBlock = null;
+    Dictionary<string, Cuboidi> attachmentAreas;
+
+    public override void Initialize(JsonObject properties)
+    {
+        base.Initialize(properties);
+
+        handleDrops = properties["handleDrops"].AsBool(true);
+
+        if (properties["dropBlockFace"].Exists)
+        {
+            dropBlockFace = properties["dropBlockFace"].AsString();
+        }
+        if (properties["dropBlock"].Exists)
+        {
+            dropBlock = properties["dropBlock"].AsString();
+        }
+
+        var areas = properties["attachmentAreas"].AsObject<Dictionary<string, RotatableCube>>(null);
+        attachmentAreas = new Dictionary<string, Cuboidi>();
+        if (areas != null)
+        {
+            foreach (var val in areas)
+            {
+                val.Value.Origin.Set(8, 8, 8);
+                attachmentAreas[val.Key] = val.Value.RotatedCopy().ConvertToCuboidi();
+            }
+        }
+        else
+        {
+            attachmentAreas["up"] = properties["attachmentArea"].AsObject<Cuboidi>(null);
+        }
+    }
+
+    public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref EnumHandling handling, ref string failureCode)
+    {
+        handling = EnumHandling.PreventDefault;
+
+        // Prefer selected block face
+        if (blockSel.Face.IsHorizontal)
+        {
+            if (TryAttachTo(world, byPlayer, blockSel, itemstack, ref failureCode)) return true;
+        }
+
+        // Otherwise attach to any possible face
+        BlockFacing[] faces = BlockFacing.HORIZONTALS;
+        blockSel = blockSel.Clone();
+        for (int i = 0; i < faces.Length; i++)
+        {
+            blockSel.Face = faces[i];
+            if (TryAttachTo(world, byPlayer, blockSel, itemstack, ref failureCode)) return true;
+        }
+
+        failureCode = "requirehorizontalattachable";
+
+        return false;
+    }
+
+    public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, ref float dropQuantityMultiplier, ref EnumHandling handled)
+    {
+        if (handleDrops)
+        {
+            return [OnPickBlock(world, pos, ref handled)];
+        }
+        else
+        {
+            handled = EnumHandling.PassThrough;
+            return null;
+        }
+    }
+
+    public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventSubsequent;
+
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            handled = EnumHandling.PassThrough;
+            return null;
+        }
+
+        if (dropBlock != null)
+        {
+            ItemStack stack = new ItemStack(world.BlockAccessor.GetBlock(new AssetLocation(dropBlock)));
+            beBehavior.Variants.ToStack(stack);
+            return stack;
+        }
+        
+        ItemStack _stack = new ItemStack(world.BlockAccessor.GetBlock(block.CodeWithParts(dropBlockFace)));
+        beBehavior.Variants.ToStack(_stack);
+        return _stack;
+    }
+
+    public override void OnNeighbourBlockChange(IWorldAccessor world, BlockPos pos, BlockPos neibpos, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventDefault;
+
+        if (!CanBlockStay(world, pos))
+        {
+            world.BlockAccessor.BreakBlock(pos, null);
+        }
+    }
+
+    bool TryAttachTo(IWorldAccessor world, IPlayer player, BlockSelection blockSel, ItemStack itemstack, ref string failureCode)
+    {
+        BlockFacing oppositeFace = blockSel.Face.Opposite;
+
+        BlockPos attachingBlockPos = blockSel.Position.AddCopy(oppositeFace);
+        Block attachingBlock = world.BlockAccessor.GetBlock(attachingBlockPos);
+        Block orientedBlock = world.BlockAccessor.GetBlock(block.CodeWithParts(oppositeFace.Code));
+
+        Cuboidi attachmentArea = null;
+        attachmentAreas?.TryGetValue(oppositeFace.Code, out attachmentArea);
+
+        if (attachingBlock.CanAttachBlockAt(world.BlockAccessor, block, attachingBlockPos, blockSel.Face, attachmentArea) && orientedBlock.CanPlaceBlock(world, player, blockSel, ref failureCode))
+        {
+            orientedBlock.DoPlaceBlock(world, player, blockSel, itemstack);
+            return true;
+        }
+        return false;
+    }
+
+    bool CanBlockStay(IWorldAccessor world, BlockPos pos)
+    {
+        string[] parts = block.Code.Path.Split('-');
+        BlockFacing facing = BlockFacing.FromCode(parts[parts.Length - 1]);
+        Block attachingblock = world.BlockAccessor.GetBlock(pos.AddCopy(facing));
+
+        Cuboidi attachmentArea = null;
+        attachmentAreas?.TryGetValue(facing.Code, out attachmentArea);
+
+        return attachingblock.CanAttachBlockAt(world.BlockAccessor, block, pos.AddCopy(facing), facing.Opposite, attachmentArea);
+    }
+
+    public override bool CanAttachBlockAt(IBlockAccessor world, Block block, BlockPos pos, BlockFacing blockFace, ref EnumHandling handled, Cuboidi attachmentArea = null)
+    {
+        handled = EnumHandling.PreventDefault;
+        return false;
+    }
+
+    public override AssetLocation GetRotatedBlockCode(int angle, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventDefault;
+
+        BlockFacing beforeFacing = BlockFacing.FromCode(block.LastCodePart());
+        int rotatedIndex = GameMath.Mod(beforeFacing.HorizontalAngleIndex - angle / 90, 4);
+        BlockFacing nowFacing = BlockFacing.HORIZONTALS_ANGLEORDER[rotatedIndex];
+
+        return block.CodeWithParts(nowFacing.Code);
+    }
+
+    public override AssetLocation GetHorizontallyFlippedBlockCode(EnumAxis axis, ref EnumHandling handling)
+    {
+        handling = EnumHandling.PreventDefault;
+
+        BlockFacing facing = BlockFacing.FromCode(block.LastCodePart());
+        if (facing.Axis == axis)
+        {
+            return block.CodeWithParts(facing.Opposite.Code);
+        }
+        return block.Code;
+    }
+}

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorHorizontalOrientable.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorHorizontalOrientable.cs
@@ -67,7 +67,6 @@ public class BlockBehaviorHorizontalOrientable : BlockBehavior
         {
             return [drop?.ResolvedItemstack.Clone()];
         }
-
         return [OnPickBlock(world, pos, ref handled)];
     }
 

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorHorizontalOrientable.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorHorizontalOrientable.cs
@@ -1,0 +1,115 @@
+﻿using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+
+namespace AttributeRenderingLibrary;
+
+/// <summary>
+/// Version of <see cref="Vintagestory.GameContent.BlockBehaviorHorizontalOrientable"/> that works with <see cref="Variants"/>
+/// </summary>
+/// <param name="block"></param>
+public class BlockBehaviorHorizontalOrientable : BlockBehavior
+{
+    string dropBlockFace = "north";
+    string variantCode = "horizontalorientation";
+    JsonItemStack drop = null;
+
+    public BlockBehaviorHorizontalOrientable(Block block) : base(block)
+    {
+        if (!block.Variant.ContainsKey("horizontalorientation"))
+        {
+            variantCode = "side";
+        }
+    }
+
+    public override void Initialize(JsonObject properties)
+    {
+        base.Initialize(properties);
+        if (properties["dropBlockFace"].Exists)
+        {
+            dropBlockFace = properties["dropBlockFace"].AsString();
+        }
+        if (properties["drop"].Exists)
+        {
+            drop = properties["drop"].AsObject<JsonItemStack>(null, block.Code.Domain);
+        }
+    }
+
+    public override void OnLoaded(ICoreAPI api)
+    {
+        drop?.Resolve(api.World, "AttributeRenderingLibrary.HorizontalOrientable drop for " + block.Code);
+    }
+
+    public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref EnumHandling handling, ref string failureCode)
+    {
+        handling = EnumHandling.PreventDefault;
+        BlockFacing[] horVer = Block.SuggestedHVOrientation(byPlayer, blockSel);
+        AssetLocation blockCode = block.CodeWithVariant(variantCode, horVer[0].Code);
+        Block orientedBlock = world.BlockAccessor.GetBlock(blockCode);
+
+        if (orientedBlock == null)
+        {
+            throw new System.NullReferenceException("Unable to to find a rotated block with code " + blockCode + ", you're maybe missing the side variant group of have a dash in your block code");
+        }
+
+        if (orientedBlock.CanPlaceBlock(world, byPlayer, blockSel, ref failureCode))
+        {
+            orientedBlock.DoPlaceBlock(world, byPlayer, blockSel, itemstack);
+            return true;
+        }
+        return false;
+    }
+
+    public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, ref float dropQuantityMultiplier, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventSubsequent;
+        if (drop?.ResolvedItemstack != null)
+        {
+            return [drop?.ResolvedItemstack.Clone()];
+        }
+
+        return [OnPickBlock(world, pos, ref handled)];
+    }
+
+    public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventSubsequent;
+        if (drop != null)
+        {
+            return drop?.ResolvedItemstack.Clone();
+        }
+
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            handled = EnumHandling.PassThrough;
+            return null;
+        }
+
+        ItemStack stack = new ItemStack(world.BlockAccessor.GetBlock(block.CodeWithVariant(variantCode, dropBlockFace)));
+        beBehavior.Variants.ToStack(stack);
+        return stack;
+    }
+
+    public override AssetLocation GetRotatedBlockCode(int angle, ref EnumHandling handled)
+    {
+        handled = EnumHandling.PreventDefault;
+
+        BlockFacing beforeFacing = BlockFacing.FromCode(block.Variant[variantCode]);
+        int rotatedIndex = GameMath.Mod(beforeFacing.HorizontalAngleIndex - angle / 90, 4);
+        BlockFacing nowFacing = BlockFacing.HORIZONTALS_ANGLEORDER[rotatedIndex];
+
+        return block.CodeWithVariant(variantCode, nowFacing.Code);
+    }
+
+    public override AssetLocation GetHorizontallyFlippedBlockCode(EnumAxis axis, ref EnumHandling handling)
+    {
+        handling = EnumHandling.PreventDefault;
+
+        BlockFacing facing = BlockFacing.FromCode(block.Variant[variantCode]);
+        if (facing.Axis == axis)
+        {
+            return block.CodeWithVariant(variantCode, facing.Opposite.Code);
+        }
+        return block.Code;
+    }
+}

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -1,0 +1,299 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Util;
+
+namespace AttributeRenderingLibrary;
+
+public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlockBehavior(block), IShapeTexturesFromAttributes
+{
+    public Dictionary<string, List<object>> NameByType { get; protected set; } = new();
+    public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
+
+    public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
+    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
+    private ICoreClientAPI clientApi;
+
+    public override void OnLoaded(ICoreAPI api)
+    {
+        clientApi = api as ICoreClientAPI;
+    }
+
+    public override void Initialize(JsonObject properties)
+    {
+        base.Initialize(properties);
+
+        if (properties != null)
+        {
+            NameByType = properties["name"].AsObject<Dictionary<string, List<object>>>();
+            DescriptionByType = properties["description"].AsObject<Dictionary<string, List<object>>>();
+
+            shapeByType = properties["shape"].AsObject<Dictionary<string, CompositeShape>>();
+            texturesByType = properties["textures"].AsObject<Dictionary<string, Dictionary<string, CompositeTexture>>>();
+        }
+    }
+
+    public override void OnUnloaded(ICoreAPI api)
+    {
+        Dictionary<string, MultiTextureMeshRef> meshRefs = ObjectCacheUtil.TryGet<Dictionary<string, MultiTextureMeshRef>>(api, "AttributeRenderingLibrary_BehaviorShapeTexturesFromAttributes_MeshRefs");
+        meshRefs?.Foreach(meshRef => meshRef.Value?.Dispose());
+        ObjectCacheUtil.Delete(api, "AttributeRenderingLibrary_BehaviorShapeTexturesFromAttributes_MeshRefs");
+
+        Dictionary<string, MeshData> meshes = ObjectCacheUtil.TryGet<Dictionary<string, MeshData>>(api, "AttributeRenderingLibrary_BehaviorShapeTexturesFromAttributes_Meshes");
+        meshes?.Foreach(mesh => mesh.Value?.Dispose());
+        ObjectCacheUtil.Delete(api, "AttributeRenderingLibrary_BehaviorShapeTexturesFromAttributes_Meshes");
+    }
+
+    public override bool DoPlaceBlock(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ItemStack byItemStack, ref EnumHandling handling)
+    {
+        if (world.BlockAccessor.GetBlockEntity(blockSel.Position)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            beBehavior.OnBlockPlaced(byItemStack);
+            handling = EnumHandling.Handled;
+        }
+        return true;
+    }
+
+    public virtual MeshData GenGuiMesh(ItemStack itemstack)
+    {
+        MeshData mesh = RenderExtensions.GenEmptyMesh();
+
+        Variants variants = Variants.FromStack(itemstack);
+        variants.FindByVariant(shapeByType, out CompositeShape ucshape);
+        ucshape ??= block.Shape;
+
+        if (ucshape == null) return mesh;
+
+        CompositeShape rcshape = variants.ReplacePlaceholders(ucshape.Clone());
+        rcshape.Base = rcshape.Base.CopyWithPathPrefixAndAppendixOnce("shapes/", ".json");
+
+        Shape shape = clientApi.Assets.TryGet(rcshape.Base)?.ToObject<Shape>();
+        if (shape == null) return mesh;
+
+        UniversalShapeTextureSource stexSource = new UniversalShapeTextureSource(clientApi, clientApi.BlockTextureAtlas, shape, rcshape.Base.ToString());
+        Dictionary<string, AssetLocation> prefixedTextureCodes = null;
+        string overlayPrefix = "";
+
+        if (rcshape.Overlays != null && rcshape.Overlays.Length > 0)
+        {
+            overlayPrefix = GetMeshCacheKey(itemstack);
+            prefixedTextureCodes = ShapeOverlayHelper.AddOverlays(clientApi, overlayPrefix, variants, stexSource, shape, rcshape);
+        }
+
+        foreach ((string textureCode, CompositeTexture texture) in itemstack.Block.Textures)
+        {
+            stexSource.textures[textureCode] = texture;
+        }
+
+        ShapeOverlayHelper.BakeVariantTextures(clientApi, stexSource, variants, texturesByType, prefixedTextureCodes, overlayPrefix);
+
+        clientApi.Tesselator.TesselateShape("ShapeTexturesFromAttributes blockbehavior", shape, out mesh, stexSource, quantityElements: rcshape.QuantityElements, selectiveElements: rcshape.SelectiveElements);
+        return mesh;
+    }
+
+    public virtual MeshData GetOrCreateMesh(Variants variants, ITexPositionSource overrideTexturesource = null)
+    {
+        Dictionary<string, MeshData> cMeshes = ObjectCacheUtil.GetOrCreate(clientApi, "AttributeRenderingLibrary_BehaviorShapeTexturesFromAttributes_Meshes", () => new Dictionary<string, MeshData>());
+
+        string key = $"{block.Code}-{variants}";
+        if (overrideTexturesource != null || !cMeshes.TryGetValue(key, out MeshData mesh))
+        {
+            mesh = RenderExtensions.GenEmptyMesh();
+
+            variants.FindByVariant(shapeByType, out CompositeShape ucshape);
+            ucshape ??= block.Shape;
+
+            if (ucshape == null) return mesh;
+
+            CompositeShape rcshape = variants.ReplacePlaceholders(ucshape.Clone());
+            rcshape.Base = rcshape.Base.CopyWithPathPrefixAndAppendixOnce("shapes/", ".json");
+
+            Shape shape = clientApi.Assets.TryGet(rcshape.Base)?.ToObject<Shape>();
+            if (shape == null) return mesh;
+
+            UniversalShapeTextureSource stexSource = new UniversalShapeTextureSource(clientApi, clientApi.BlockTextureAtlas, shape, rcshape.Base.ToString());
+            Dictionary<string, AssetLocation> prefixedTextureCodes = null;
+            string overlayPrefix = "";
+
+            if (rcshape.Overlays != null && rcshape.Overlays.Length > 0)
+            {
+                overlayPrefix = key;
+                prefixedTextureCodes = ShapeOverlayHelper.AddOverlays(clientApi, overlayPrefix, variants, stexSource, shape, rcshape);
+            }
+
+            foreach ((string textureCode, CompositeTexture texture) in block.Textures)
+            {
+                stexSource.textures[textureCode] = texture;
+            }
+
+            ShapeOverlayHelper.BakeVariantTextures(clientApi, stexSource, variants, texturesByType, prefixedTextureCodes, overlayPrefix);
+
+            clientApi.Tesselator.TesselateShape("ShapeTexturesFromAttributes blockbehavior", shape, out mesh, stexSource, quantityElements: rcshape.QuantityElements, selectiveElements: rcshape.SelectiveElements);
+
+            if (overrideTexturesource == null)
+            {
+                cMeshes[key] = mesh;
+            }
+        }
+        return mesh;
+    }
+
+    public override void OnBeforeRender(ICoreClientAPI clientApi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
+    {
+        Dictionary<string, MultiTextureMeshRef> meshRefs = ObjectCacheUtil.GetOrCreate(clientApi, "AttributeRenderingLibrary_BehaviorShapeTexturesFromAttributes_MeshRefs", () => new Dictionary<string, MultiTextureMeshRef>());
+
+        string key = GetMeshCacheKey(itemstack);
+
+        if (!meshRefs.TryGetValue(key, out MultiTextureMeshRef meshref))
+        {
+            MeshData mesh = GenGuiMesh(itemstack);
+            meshref = clientApi.Render.UploadMultiTextureMesh(mesh);
+            meshRefs[key] = meshref;
+        }
+
+        renderinfo.ModelRef = meshref;
+        renderinfo.NormalShaded = true;
+
+        base.OnBeforeRender(clientApi, itemstack, target, ref renderinfo);
+    }
+
+    public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, ref float dropChanceMultiplier, ref EnumHandling handling)
+    {
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            handling = EnumHandling.PassThrough;
+            return null;
+        }
+
+        handling = EnumHandling.Handled;
+        return [OnPickBlock(world, pos, ref handling)];
+    }
+
+    public override void GetDecal(IWorldAccessor world, BlockPos pos, ITexPositionSource decalTexSource, ref MeshData decalModelData, ref MeshData blockModelData, ref EnumHandling handled)
+    {
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            handled = EnumHandling.PassThrough;
+            return;
+        }
+
+        Vec3f rotationRad = GetRotation(world, pos);
+        float[] mat = Matrixf.Create().Translate(0.5f, 0.5f, 0.5f).Rotate(rotationRad).Translate(-0.5f, -0.5f, -0.5f).Values;
+        MeshData decalMesh = GetOrCreateMesh(beBehavior.Variants, overrideTexturesource: decalTexSource).Clone().MatrixTransform(mat);
+        MeshData blockMesh = GetOrCreateMesh(beBehavior.Variants).Clone().MatrixTransform(mat);
+        decalModelData = decalMesh;
+        blockModelData = blockMesh;
+        return;
+    }
+
+    /// <summary>
+    /// Rotation (in radians) for the block at the given position
+    /// </summary>
+    /// <param name="world"></param>
+    /// <param name="pos"></param>
+    /// <returns></returns>
+    public virtual Vec3f GetRotation(IWorldAccessor world, BlockPos pos)
+    {
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            return Vec3f.Zero;
+        }
+
+        beBehavior.Variants.FindByVariant(shapeByType, out CompositeShape shapeForRotation);
+        shapeForRotation ??= block.Shape;
+
+        return new Vec3f
+        {
+            X = (shapeForRotation?.rotateX ?? 0) * GameMath.DEG2RAD,
+            Y = (shapeForRotation?.rotateY ?? 0) * GameMath.DEG2RAD,
+            Z = (shapeForRotation?.rotateZ ?? 0) * GameMath.DEG2RAD
+        };
+    }
+
+    public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos, ref EnumHandling handling)
+    {
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            handling = EnumHandling.Handled;
+            ItemStack stack = new ItemStack(block);
+            beBehavior.Variants.ToStack(stack);
+            return stack;
+        }
+
+        handling = EnumHandling.PassThrough;
+        return null;
+    }
+
+    public override void GetHeldItemName(StringBuilder sb, ItemStack itemStack)
+    {
+        if (NameByType == null || !NameByType.Any())
+        {
+            return;
+        }
+
+        Variants variants = Variants.FromStack(itemStack);
+        variants.FindByVariant(NameByType, out List<object> _langKeys);
+
+        string name = variants.GetName(_langKeys);
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        sb.Clear();
+        sb.Append(name);
+    }
+
+    public override void GetPlacedBlockName(StringBuilder sb, IWorldAccessor world, BlockPos pos)
+    {
+        if (NameByType == null || !NameByType.Any())
+        {
+            return;
+        }
+
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            return;
+        }
+
+        Variants variants = beBehavior.Variants;
+        variants.FindByVariant(NameByType, out List<object> _langKeys);
+
+        string name = variants.GetName(_langKeys);
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        sb.Clear();
+        sb.Append(name);
+
+    }
+
+    public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
+    {
+        if (DescriptionByType == null || !DescriptionByType.Any())
+        {
+            return;
+        }
+
+        Variants variants = Variants.FromStack(inSlot.Itemstack);
+        variants.FindByVariant(DescriptionByType, out List<object> _langKeys);
+        variants.GetDescription(dsc, _langKeys);
+        variants.GetDebugDescription(dsc, withDebugInfo);
+    }
+
+    public virtual MeshData GenMesh(ItemStack itemstack, ITextureAtlasAPI targetAtlas, BlockPos atBlockPos)
+    {
+        return GenGuiMesh(itemstack);
+    }
+
+    public virtual string GetMeshCacheKey(ItemStack itemstack)
+    {
+        return $"{itemstack.Collectible.Code}-{Variants.FromStack(itemstack)}";
+    }
+}

--- a/AttributeRenderingLibrary/BlockEntityBehavior/BlockEntityBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockEntityBehavior/BlockEntityBehaviorShapeTexturesFromAttributes.cs
@@ -1,0 +1,59 @@
+﻿using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+
+namespace AttributeRenderingLibrary;
+
+public class BlockEntityBehaviorShapeTexturesFromAttributes(BlockEntity blockentity) : BlockEntityBehavior(blockentity)
+{
+    public BlockBehaviorShapeTexturesFromAttributes OwnBehavior => Block?.GetBehavior<BlockBehaviorShapeTexturesFromAttributes>();
+    public Variants Variants { get; protected set; } = new Variants();
+    protected MeshData mesh;
+
+    public override void Initialize(ICoreAPI api, JsonObject properties)
+    {
+        base.Initialize(api, properties);
+        if (mesh == null) Init();
+    }
+
+    protected void Init()
+    {
+        if (Api == null || OwnBehavior == null) return;
+
+        if (Api.Side == EnumAppSide.Client)
+        {
+            mesh = OwnBehavior.GetOrCreateMesh(Variants);
+        }
+    }
+
+    public override void ToTreeAttributes(ITreeAttribute tree)
+    {
+        base.ToTreeAttributes(tree);
+        Variants.ToTreeAttribute(tree);
+    }
+
+    public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldForResolving)
+    {
+        Variants = Variants.FromTreeAttribute(tree);
+        base.FromTreeAttributes(tree, worldForResolving);
+    }
+
+    public override void OnBlockPlaced(ItemStack byItemStack = null)
+    {
+        if (byItemStack != null)
+        {
+            Variants = Variants.FromStack(byItemStack);
+        }
+        Init();
+    }
+
+    public override bool OnTesselation(ITerrainMeshPool mesher, ITesselatorAPI tessThreadTesselator)
+    {
+        Vec3f rotationRad = OwnBehavior.GetRotation(Api.World, Pos);
+        MeshData clonedMesh = mesh.Clone();
+        clonedMesh = clonedMesh.Rotate(Vec3f.Half, rotationRad.X, rotationRad.Y, rotationRad.Z);
+        mesher.AddMeshData(clonedMesh);
+        return true; // skip default mesh
+    }
+}

--- a/AttributeRenderingLibrary/HarmonyPatches/GetDropsForHandbookPatch.cs
+++ b/AttributeRenderingLibrary/HarmonyPatches/GetDropsForHandbookPatch.cs
@@ -1,0 +1,29 @@
+﻿
+using HarmonyLib;
+using System.Runtime.CompilerServices;
+using Vintagestory.API.Common;
+
+namespace AttributeRenderingLibrary;
+
+[HarmonyPatch(typeof(Block), nameof(Block.GetDropsForHandbook))]
+public static class GetDropsForHandbookPatch
+{
+    [HarmonyReversePatch(HarmonyReversePatchType.Original)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static BlockDropItemStack[] Base(this Block instance, ItemStack handbookStack, IPlayer forPlayer) => default;
+
+    [HarmonyPrefix]
+    public static bool Prefix(Block __instance, ref BlockDropItemStack[] __result, ItemStack handbookStack, IPlayer forPlayer)
+    {
+        if (handbookStack?.Collectible?.GetCollectibleInterface<IShapeTexturesFromAttributes>() is not IShapeTexturesFromAttributes shapeTexturesFromAttributes)
+        {
+            return true;
+        }
+
+        BlockDropItemStack[] drops = Base(__instance, handbookStack, forPlayer) ?? [];
+        drops[0] = drops[0].Clone();
+        drops[0].ResolvedItemstack.SetFrom(handbookStack);
+        __result = drops;
+        return false;
+    }
+}

--- a/AttributeRenderingLibrary/Item/ItemShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/Item/ItemShapeTexturesFromAttributes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;

--- a/AttributeRenderingLibrary/Systems/Core.cs
+++ b/AttributeRenderingLibrary/Systems/Core.cs
@@ -18,6 +18,8 @@ public class Core : ModSystem
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.ShapeTexturesFromAttributes", typeof(CollectibleBehaviorShapeTexturesFromAttributes));
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.ContainedTransform", typeof(CollectibleBehaviorContainedTransform));
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.HeldBagTyped", typeof(CollectibleBehaviorHeldBagTyped));
+        api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.BlockShapeTexturesFromAttributes", typeof(BlockBehaviorShapeTexturesFromAttributes));
+        api.RegisterBlockEntityBehaviorClass("AttributeRenderingLibrary.ShapeTexturesFromAttributes", typeof(BlockEntityBehaviorShapeTexturesFromAttributes));
         Mod.Logger.Event("started '{0}' mod", Mod.Info.Name);
     }
 

--- a/AttributeRenderingLibrary/Systems/Core.cs
+++ b/AttributeRenderingLibrary/Systems/Core.cs
@@ -19,7 +19,8 @@ public class Core : ModSystem
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.ContainedTransform", typeof(CollectibleBehaviorContainedTransform));
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.HeldBagTyped", typeof(CollectibleBehaviorHeldBagTyped));
         api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.BlockShapeTexturesFromAttributes", typeof(BlockBehaviorShapeTexturesFromAttributes));
-        api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.HorizontalOrientable", typeof(BlockBehaviorHorizontalOrientable));
+        api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.HorizontalOrientable", typeof(AttributeRenderingLibrary.BlockBehaviorHorizontalOrientable));
+        api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.HorizontalAttachable", typeof(AttributeRenderingLibrary.BlockBehaviorHorizontalAttachable));
         api.RegisterBlockEntityBehaviorClass("AttributeRenderingLibrary.ShapeTexturesFromAttributes", typeof(BlockEntityBehaviorShapeTexturesFromAttributes));
         Mod.Logger.Event("started '{0}' mod", Mod.Info.Name);
     }

--- a/AttributeRenderingLibrary/Systems/Core.cs
+++ b/AttributeRenderingLibrary/Systems/Core.cs
@@ -19,6 +19,7 @@ public class Core : ModSystem
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.ContainedTransform", typeof(CollectibleBehaviorContainedTransform));
         api.RegisterCollectibleBehaviorClass("AttributeRenderingLibrary.HeldBagTyped", typeof(CollectibleBehaviorHeldBagTyped));
         api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.BlockShapeTexturesFromAttributes", typeof(BlockBehaviorShapeTexturesFromAttributes));
+        api.RegisterBlockBehaviorClass("AttributeRenderingLibrary.HorizontalOrientable", typeof(BlockBehaviorHorizontalOrientable));
         api.RegisterBlockEntityBehaviorClass("AttributeRenderingLibrary.ShapeTexturesFromAttributes", typeof(BlockEntityBehaviorShapeTexturesFromAttributes));
         Mod.Logger.Event("started '{0}' mod", Mod.Info.Name);
     }

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -4,7 +4,7 @@
     "name": "Attribute Rendering Library",
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "description": "Attribute-based variant system for rendering things.",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "dependencies": {
         "game": "1.21.0"
     }


### PR DESCRIPTION
Implemented following classes with Variants support:
- `BlockBehaviorShapeTexturesFromAttributes` (`"AttributeRenderingLibrary.BlockShapeTexturesFromAttributes"`);
- `BlockEntityBehaviorShapeTexturesFromAttributes` (`"AttributeRenderingLibrary.ShapeTexturesFromAttributes"`);
- `BlockBehaviorHorizontalOrientable` (`"AttributeRenderingLibrary.HorizontalOrientable"`)
- `BlockBehaviorHorizontalAttachable` (`"AttributeRenderingLibrary.HorizontalAttachable"`)