### PR TITLE
Hitboxes, drops and more

### DIFF
--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -13,6 +13,8 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 {
     public Dictionary<string, List<object>> NameByType { get; protected set; } = new();
     public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
+    public Dictionary<string, Cuboidf[]> CollisionBoxesByType { get; protected set; } = new();
+    public Dictionary<string, Cuboidf[]> SelectionBoxesByType { get; protected set; } = new();
 
     public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
     public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
@@ -34,6 +36,26 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
             shapeByType = properties["shape"].AsObject<Dictionary<string, CompositeShape>>();
             texturesByType = properties["textures"].AsObject<Dictionary<string, Dictionary<string, CompositeTexture>>>();
+
+            LoadAndResolveCollisionAndSelectionBoxes(properties);
+        }
+    }
+
+    private void LoadAndResolveCollisionAndSelectionBoxes(JsonObject properties)
+    {
+        Dictionary<string, RotatableCube[]> rawCollisionsAndSelections = properties["collisionSelectionBoxes"]?.AsObject<Dictionary<string, RotatableCube[]>>();
+        Dictionary<string, RotatableCube[]> rawCollisions = properties["collisionBoxes"]?.AsObject<Dictionary<string, RotatableCube[]>>();
+        Dictionary<string, RotatableCube[]> rawSelections = properties["selectionBoxes"]?.AsObject<Dictionary<string, RotatableCube[]>>();
+
+        if (rawCollisionsAndSelections?.Count > 0)
+        {
+            CollisionBoxesByType = rawCollisionsAndSelections?.ToDictionary(x => x.Key, x => x.Value.ToCuboidf());
+            SelectionBoxesByType = rawCollisionsAndSelections?.ToDictionary(x => x.Key, x => x.Value.ToCuboidf());
+        }
+        else
+        {
+            CollisionBoxesByType = rawCollisions?.ToDictionary(x => x.Key, x => x.Value.ToCuboidf());
+            SelectionBoxesByType = rawSelections?.ToDictionary(x => x.Key, x => x.Value.ToCuboidf());
         }
     }
 
@@ -295,5 +317,31 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
     public virtual string GetMeshCacheKey(ItemStack itemstack)
     {
         return $"{itemstack.Collectible.Code}-{Variants.FromStack(itemstack)}";
+    }
+
+    public override Cuboidf[] GetCollisionBoxes(IBlockAccessor blockAccessor, BlockPos pos, ref EnumHandling handled)
+    {
+        if (blockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior
+            && beBehavior.Variants.FindByVariant(CollisionBoxesByType, out Cuboidf[] cuboids)
+            && cuboids != null
+            && cuboids.Length > 0)
+        {
+            handled = EnumHandling.PreventSubsequent;
+            return cuboids;
+        }
+        return base.GetCollisionBoxes(blockAccessor, pos, ref handled);
+    }
+
+    public override Cuboidf[] GetSelectionBoxes(IBlockAccessor blockAccessor, BlockPos pos, ref EnumHandling handled)
+    {
+        if (blockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior
+            && beBehavior.Variants.FindByVariant(SelectionBoxesByType, out Cuboidf[] cuboids)
+            && cuboids != null
+            && cuboids.Length > 0)
+        {
+            handled = EnumHandling.PreventSubsequent;
+            return cuboids;
+        }
+        return base.GetSelectionBoxes(blockAccessor, pos, ref handled);
     }
 }

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -228,7 +228,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
                 for (int i = 0; i < unresolvedDrops.Length; i++)
                 {
                     BlockDropItemStack dstack = beBehavior.Variants.ReplacePlaceholders(unresolvedDrops[i].Clone());
-                    if (!dstack.Resolve(world, "", ""))
+                    if (!dstack.Resolve(world, "AttributeRenderingLibrary.BlockShapeTexturesFromAttributes", dstack.Code))
                     {
                         break;
                     }

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -220,7 +220,11 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
                 List<ItemStack> todrop = [];
                 for (int i = 0; i < unresolvedDrops.Length; i++)
                 {
-                    BlockDropItemStack dstack = unresolvedDrops[i];
+                    BlockDropItemStack dstack = beBehavior.Variants.ReplacePlaceholders(unresolvedDrops[i].Clone());
+                    if (!dstack.Resolve(world, "", ""))
+                    {
+                        break;
+                    }
                     ItemStack stack = dstack.ToRandomItemstackForPlayer(byPlayer, world, dropQuantityMultiplier);
                     if (stack != null)
                     {
@@ -231,7 +235,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
                         }
                     }
                 }
-                handling = EnumHandling.Handled;
+                handling = EnumHandling.PreventSubsequent;
                 return todrop.ToArray();
             }
 
@@ -247,7 +251,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
     {
         if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
         {
-            handling = EnumHandling.Handled;
+            handling = EnumHandling.PreventSubsequent;
             ItemStack stack = new ItemStack(block);
             beBehavior.Variants.ToStack(stack);
             return stack;

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -12,15 +12,15 @@ namespace AttributeRenderingLibrary;
 
 public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlockBehavior(block), IBlockShapeTexturesFromAttributes
 {
-    public Dictionary<string, List<object>> NameByType { get; protected set; } = new();
-    public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
-    public Dictionary<string, Cuboidf[]> CollisionBoxesByType { get; protected set; } = new();
-    public Dictionary<string, Cuboidf[]> SelectionBoxesByType { get; protected set; } = new();
-    public Dictionary<string, BlockDropItemStack[]> DropsByType { get; protected set; } = new();
+    public Dictionary<string, List<object>> NameByType { get; protected set; }
+    public Dictionary<string, List<object>> DescriptionByType { get; protected set; }
+    public Dictionary<string, Cuboidf[]> CollisionBoxesByType { get; protected set; }
+    public Dictionary<string, Cuboidf[]> SelectionBoxesByType { get; protected set; }
+    public Dictionary<string, BlockDropItemStack[]> DropsByType { get; protected set; }
 
-    public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
-    public Dictionary<string, CompositeShape> shapeInventoryByType { get; protected set; } = new();
-    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
+    public Dictionary<string, CompositeShape> shapeByType { get; protected set; }
+    public Dictionary<string, CompositeShape> shapeInventoryByType { get; protected set; }
+    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; }
     private ICoreClientAPI clientApi;
 
     public override void OnLoaded(ICoreAPI api)
@@ -311,7 +311,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
     public override void GetHeldItemName(StringBuilder sb, ItemStack itemStack)
     {
-        if (NameByType == null || !NameByType.Any())
+        if (NameByType == null || NameByType.Count == 0)
         {
             return;
         }
@@ -331,7 +331,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
     public override void GetPlacedBlockName(StringBuilder sb, IWorldAccessor world, BlockPos pos)
     {
-        if (NameByType == null || !NameByType.Any())
+        if (NameByType == null || NameByType.Count == 0)
         {
             return;
         }
@@ -357,7 +357,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
     public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
     {
-        if (DescriptionByType == null || !DescriptionByType.Any())
+        if (DescriptionByType == null || DescriptionByType.Count == 0)
         {
             return;
         }

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Vintagestory.API.Client;
@@ -24,6 +25,10 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
     public override void OnLoaded(ICoreAPI api)
     {
+        // blocks with this behavior cannot be chiseled
+        block.Attributes ??= new JsonObject(new JObject());
+        block.Attributes.Token["canChisel"] = JToken.FromObject(false);
+
         clientApi = api as ICoreClientAPI;
     }
 

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -115,7 +115,16 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
         ShapeOverlayHelper.BakeVariantTextures(clientApi, stexSource, variants, texturesByType, prefixedTextureCodes, overlayPrefix);
 
-        clientApi.Tesselator.TesselateShape("ShapeTexturesFromAttributes blockbehavior", shape, out mesh, stexSource, quantityElements: rcshape.QuantityElements, selectiveElements: rcshape.SelectiveElements);
+        TesselationMetaData meta = new TesselationMetaData
+        {
+            QuantityElements = rcshape.QuantityElements,
+            SelectiveElements = rcshape.SelectiveElements,
+            IgnoreElements = rcshape.IgnoreElements,
+            TexSource = stexSource,
+            TypeForLogging = "ShapeTexturesFromAttributes block behavior"
+        };
+
+        clientApi.Tesselator.TesselateShape(meta, shape, out mesh);
         return mesh;
     }
 
@@ -156,7 +165,16 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
 
             ShapeOverlayHelper.BakeVariantTextures(clientApi, stexSource, variants, texturesByType, prefixedTextureCodes, overlayPrefix);
 
-            clientApi.Tesselator.TesselateShape("ShapeTexturesFromAttributes blockbehavior", shape, out mesh, stexSource, quantityElements: rcshape.QuantityElements, selectiveElements: rcshape.SelectiveElements);
+            TesselationMetaData meta = new TesselationMetaData
+            {
+                QuantityElements = rcshape.QuantityElements,
+                SelectiveElements = rcshape.SelectiveElements,
+                IgnoreElements = rcshape.IgnoreElements,
+                TexSource = stexSource,
+                TypeForLogging = "ShapeTexturesFromAttributes block behavior"
+            };
+
+            clientApi.Tesselator.TesselateShape(meta, shape, out mesh);
 
             if (overrideTexturesource == null)
             {

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -18,6 +18,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
     public Dictionary<string, BlockDropItemStack[]> DropsByType { get; protected set; } = new();
 
     public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
+    public Dictionary<string, CompositeShape> shapeInventoryByType { get; protected set; } = new();
     public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
     private ICoreClientAPI clientApi;
 
@@ -37,6 +38,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
             DropsByType = properties["drops"].AsObject<Dictionary<string, BlockDropItemStack[]>>();
 
             shapeByType = properties["shape"].AsObject<Dictionary<string, CompositeShape>>();
+            shapeInventoryByType = properties["shapeInventory"].AsObject<Dictionary<string, CompositeShape>>();
             texturesByType = properties["textures"].AsObject<Dictionary<string, Dictionary<string, CompositeTexture>>>();
 
             LoadAndResolveCollisionAndSelectionBoxes(properties);
@@ -87,8 +89,14 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
         MeshData mesh = RenderExtensions.GenEmptyMesh();
 
         Variants variants = Variants.FromStack(itemstack);
-        variants.FindByVariant(shapeByType, out CompositeShape ucshape);
-        ucshape ??= block.Shape;
+        variants.FindByVariant(shapeInventoryByType, out CompositeShape ucshape);
+
+        if (ucshape == null)
+        {
+            variants.FindByVariant(shapeByType, out ucshape);
+        }
+
+        ucshape ??= block.ShapeInventory ?? block.Shape;
 
         if (ucshape == null) return mesh;
 

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -9,7 +9,7 @@ using Vintagestory.API.Util;
 
 namespace AttributeRenderingLibrary;
 
-public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlockBehavior(block), IShapeTexturesFromAttributes
+public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlockBehavior(block), IBlockShapeTexturesFromAttributes
 {
     public Dictionary<string, List<object>> NameByType { get; protected set; } = new();
     public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
@@ -215,9 +215,11 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
     {
         if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
         {
-            if (beBehavior.Variants.FindByVariant(DropsByType, out BlockDropItemStack[] unresolvedDrops))
+            if (beBehavior.Variants.FindByVariant(DropsByType, out BlockDropItemStack[] unresolvedDrops)
+                && unresolvedDrops != null
+                && unresolvedDrops.Length > 0)
             {
-                List<ItemStack> todrop = [];
+                List<ItemStack> resolvedDrops = new(unresolvedDrops.Length);
                 for (int i = 0; i < unresolvedDrops.Length; i++)
                 {
                     BlockDropItemStack dstack = beBehavior.Variants.ReplacePlaceholders(unresolvedDrops[i].Clone());
@@ -228,7 +230,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
                     ItemStack stack = dstack.ToRandomItemstackForPlayer(byPlayer, world, dropQuantityMultiplier);
                     if (stack != null)
                     {
-                        todrop.Add(stack);
+                        resolvedDrops.Add(stack);
                         if (dstack.LastDrop)
                         {
                             break;
@@ -236,7 +238,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
                     }
                 }
                 handling = EnumHandling.PreventSubsequent;
-                return todrop.ToArray();
+                return resolvedDrops.ToArray();
             }
 
             handling = EnumHandling.Handled;

--- a/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs
@@ -15,6 +15,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
     public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
     public Dictionary<string, Cuboidf[]> CollisionBoxesByType { get; protected set; } = new();
     public Dictionary<string, Cuboidf[]> SelectionBoxesByType { get; protected set; } = new();
+    public Dictionary<string, BlockDropItemStack[]> DropsByType { get; protected set; } = new();
 
     public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
     public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
@@ -33,6 +34,7 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
         {
             NameByType = properties["name"].AsObject<Dictionary<string, List<object>>>();
             DescriptionByType = properties["description"].AsObject<Dictionary<string, List<object>>>();
+            DropsByType = properties["drops"].AsObject<Dictionary<string, BlockDropItemStack[]>>();
 
             shapeByType = properties["shape"].AsObject<Dictionary<string, CompositeShape>>();
             texturesByType = properties["textures"].AsObject<Dictionary<string, Dictionary<string, CompositeTexture>>>();
@@ -183,16 +185,50 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
         base.OnBeforeRender(clientApi, itemstack, target, ref renderinfo);
     }
 
-    public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, ref float dropChanceMultiplier, ref EnumHandling handling)
+    public override ItemStack[] GetDrops(IWorldAccessor world, BlockPos pos, IPlayer byPlayer, ref float dropQuantityMultiplier, ref EnumHandling handling)
     {
-        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is not BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
         {
-            handling = EnumHandling.PassThrough;
-            return null;
+            if (beBehavior.Variants.FindByVariant(DropsByType, out BlockDropItemStack[] unresolvedDrops))
+            {
+                List<ItemStack> todrop = [];
+                for (int i = 0; i < unresolvedDrops.Length; i++)
+                {
+                    BlockDropItemStack dstack = unresolvedDrops[i];
+                    ItemStack stack = dstack.ToRandomItemstackForPlayer(byPlayer, world, dropQuantityMultiplier);
+                    if (stack != null)
+                    {
+                        todrop.Add(stack);
+                        if (dstack.LastDrop)
+                        {
+                            break;
+                        }
+                    }
+                }
+                handling = EnumHandling.Handled;
+                return todrop.ToArray();
+            }
+
+            handling = EnumHandling.Handled;
+            return [OnPickBlock(world, pos, ref handling)];
         }
 
-        handling = EnumHandling.Handled;
-        return [OnPickBlock(world, pos, ref handling)];
+        handling = EnumHandling.PassThrough;
+        return null;
+    }
+
+    public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos, ref EnumHandling handling)
+    {
+        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
+        {
+            handling = EnumHandling.Handled;
+            ItemStack stack = new ItemStack(block);
+            beBehavior.Variants.ToStack(stack);
+            return stack;
+        }
+
+        handling = EnumHandling.PassThrough;
+        return null;
     }
 
     public override void GetDecal(IWorldAccessor world, BlockPos pos, ITexPositionSource decalTexSource, ref MeshData decalModelData, ref MeshData blockModelData, ref EnumHandling handled)
@@ -234,20 +270,6 @@ public class BlockBehaviorShapeTexturesFromAttributes(Block block) : StrongBlock
             Y = (shapeForRotation?.rotateY ?? 0) * GameMath.DEG2RAD,
             Z = (shapeForRotation?.rotateZ ?? 0) * GameMath.DEG2RAD
         };
-    }
-
-    public override ItemStack OnPickBlock(IWorldAccessor world, BlockPos pos, ref EnumHandling handling)
-    {
-        if (world.BlockAccessor.GetBlockEntity(pos)?.GetBehavior<BlockEntityBehaviorShapeTexturesFromAttributes>() is BlockEntityBehaviorShapeTexturesFromAttributes beBehavior)
-        {
-            handling = EnumHandling.Handled;
-            ItemStack stack = new ItemStack(block);
-            beBehavior.Variants.ToStack(stack);
-            return stack;
-        }
-
-        handling = EnumHandling.PassThrough;
-        return null;
     }
 
     public override void GetHeldItemName(StringBuilder sb, ItemStack itemStack)

--- a/AttributeRenderingLibrary/BlockEntityBehavior/BlockEntityBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/BlockEntityBehavior/BlockEntityBehaviorShapeTexturesFromAttributes.cs
@@ -37,6 +37,7 @@ public class BlockEntityBehaviorShapeTexturesFromAttributes(BlockEntity blockent
     {
         Variants = Variants.FromTreeAttribute(tree);
         base.FromTreeAttributes(tree, worldForResolving);
+        Init();
     }
 
     public override void OnBlockPlaced(ItemStack byItemStack = null)

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorContainedTransform.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorContainedTransform.cs
@@ -13,14 +13,14 @@ namespace AttributeRenderingLibrary;
 /// </summary>
 public class CollectibleBehaviorContainedTransform(CollectibleObject collObj) : CollectibleBehavior(collObj), IContainedTransform
 {
-    protected Transforms transforms;
-    protected Dictionary<string, Dictionary<string, ModelTransform>> extraTransforms;
+    public Transforms BasicTransforms { get; protected set; }
+    public Dictionary<string, Dictionary<string, ModelTransform>> ExtraTransforms { get; protected set; }
 
     public override void Initialize(JsonObject properties)
     {
         base.Initialize(properties);
-        transforms = properties["transforms"].AsObject<Transforms>();
-        extraTransforms = properties["extraTransforms"].AsObject<Dictionary<string, Dictionary<string, ModelTransform>>>()?.ToDictionary(x => x.Key.ToLowerInvariant(), x => x.Value);
+        BasicTransforms = properties["transforms"].AsObject<Transforms>();
+        ExtraTransforms = properties["extraTransforms"].AsObject<Dictionary<string, Dictionary<string, ModelTransform>>>()?.ToDictionary(x => x.Key.ToLowerInvariant(), x => x.Value);
     }
 
     public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
@@ -30,18 +30,18 @@ public class CollectibleBehaviorContainedTransform(CollectibleObject collObj) : 
 
     public void ApplyOnBeforeRenderTransform(EnumItemRenderTarget target, Variants variants, ref ModelTransform transform)
     {
-        Dictionary<string, ModelTransform> transformsByType = target switch
+        Dictionary<string, ModelTransform> basicTransformsByType = target switch
         {
-            EnumItemRenderTarget.Gui => transforms?.GuiTransform,
-            EnumItemRenderTarget.HandTp => transforms?.TpHandTransform,
-            EnumItemRenderTarget.HandTpOff => transforms?.TpOffHandTransform,
-            EnumItemRenderTarget.Ground => transforms?.GroundTransform,
+            EnumItemRenderTarget.Gui => BasicTransforms?.GuiTransform,
+            EnumItemRenderTarget.HandTp => BasicTransforms?.TpHandTransform,
+            EnumItemRenderTarget.HandTpOff => BasicTransforms?.TpOffHandTransform,
+            EnumItemRenderTarget.Ground => BasicTransforms?.GroundTransform,
             _ => null,
         };
 
-        if (transformsByType != null
-            && transformsByType.Count > 0
-            && variants.FindByVariant(transformsByType, out ModelTransform newTransform) && newTransform != null)
+        if (basicTransformsByType != null
+            && basicTransformsByType.Count > 0
+            && variants.FindByVariant(basicTransformsByType, out ModelTransform newTransform) && newTransform != null)
         {
             newTransform = newTransform.EnsureDefaultValues();
             transform = newTransform;
@@ -52,9 +52,9 @@ public class CollectibleBehaviorContainedTransform(CollectibleObject collObj) : 
     {
         attributeTransformCode = attributeTransformCode.ToLowerInvariant();
 
-        if (extraTransforms != null
-            && extraTransforms.Count > 0
-            && extraTransforms.TryGetValue(attributeTransformCode, out Dictionary<string, ModelTransform> transformsByType)
+        if (ExtraTransforms != null
+            && ExtraTransforms.Count > 0
+            && ExtraTransforms.TryGetValue(attributeTransformCode, out Dictionary<string, ModelTransform> transformsByType)
             && Variants.FromStack(stack).FindByVariant(transformsByType, out ModelTransform transform))
         {
             transform = transform.EnsureDefaultValues();

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorContainedTransform.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorContainedTransform.cs
@@ -11,57 +11,55 @@ namespace AttributeRenderingLibrary;
 /// Provides custom transformation for OnBeforeRender and collectibles stored inside a BlockEntityDisplay, 
 /// specifically for collectibles with Variants.
 /// </summary>
-public class CollectibleBehaviorContainedTransform : CollectibleBehavior, IContainedTransform
+public class CollectibleBehaviorContainedTransform(CollectibleObject collObj) : CollectibleBehavior(collObj), IContainedTransform
 {
     protected Transforms transforms;
-    protected Dictionary<string, Dictionary<string, ModelTransform>> extraTransforms = new();
-
-    public CollectibleBehaviorContainedTransform(CollectibleObject collObj) : base(collObj) { }
+    protected Dictionary<string, Dictionary<string, ModelTransform>> extraTransforms;
 
     public override void Initialize(JsonObject properties)
     {
         base.Initialize(properties);
-
-        transforms = properties["transforms"].AsObject(defaultValue: new Transforms());
-
-        extraTransforms = properties["extraTransforms"]
-            .AsObject(defaultValue: new Dictionary<string, Dictionary<string, ModelTransform>>())
-            .ToDictionary(x => x.Key.ToLowerInvariant(), x => x.Value);
+        transforms = properties["transforms"].AsObject<Transforms>();
+        extraTransforms = properties["extraTransforms"].AsObject<Dictionary<string, Dictionary<string, ModelTransform>>>()?.ToDictionary(x => x.Key.ToLowerInvariant(), x => x.Value);
     }
 
     public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
     {
-        ApplyOnBeforeRenderTransform(target, variants: Variants.FromStack(itemstack), ref renderinfo.Transform);
+        ApplyOnBeforeRenderTransform(target, Variants.FromStack(itemstack), ref renderinfo.Transform);
     }
 
-    ModelTransform? IContainedTransform.GetTransform(BlockEntityDisplay be, string attributeTransformCode, ItemStack stack)
+    public void ApplyOnBeforeRenderTransform(EnumItemRenderTarget target, Variants variants, ref ModelTransform transform)
+    {
+        Dictionary<string, ModelTransform> transformsByType = target switch
+        {
+            EnumItemRenderTarget.Gui => transforms?.GuiTransform,
+            EnumItemRenderTarget.HandTp => transforms?.TpHandTransform,
+            EnumItemRenderTarget.HandTpOff => transforms?.TpOffHandTransform,
+            EnumItemRenderTarget.Ground => transforms?.GroundTransform,
+            _ => null,
+        };
+
+        if (transformsByType != null
+            && transformsByType.Count > 0
+            && variants.FindByVariant(transformsByType, out ModelTransform newTransform) && newTransform != null)
+        {
+            newTransform = newTransform.EnsureDefaultValues();
+            transform = newTransform;
+        }
+    }
+
+    ModelTransform IContainedTransform.GetTransform(BlockEntityDisplay be, string attributeTransformCode, ItemStack stack)
     {
         attributeTransformCode = attributeTransformCode.ToLowerInvariant();
 
-        if (extraTransforms.TryGetValue(attributeTransformCode, out Dictionary<string, ModelTransform>? transformByType)
-            && Variants.FromStack(stack).FindByVariant(transformByType, out ModelTransform transform))
+        if (extraTransforms != null
+            && extraTransforms.Count > 0
+            && extraTransforms.TryGetValue(attributeTransformCode, out Dictionary<string, ModelTransform> transformsByType)
+            && Variants.FromStack(stack).FindByVariant(transformsByType, out ModelTransform transform))
         {
             transform = transform.EnsureDefaultValues();
             return transform;
         }
         return null;
-    }
-
-    public void ApplyOnBeforeRenderTransform(EnumItemRenderTarget target, Variants variants, ref ModelTransform transform)
-    {
-        Dictionary<string, ModelTransform> transformByType = target switch
-        {
-            EnumItemRenderTarget.Gui => transforms.GuiTransform,
-            EnumItemRenderTarget.HandTp => transforms.TpHandTransform,
-            EnumItemRenderTarget.HandTpOff => transforms.TpOffHandTransform,
-            EnumItemRenderTarget.Ground => transforms.GroundTransform,
-            _ => new(),
-        };
-
-        if (variants.FindByVariant(inDictionary: transformByType, out ModelTransform newTransform))
-        {
-            newTransform = newTransform.EnsureDefaultValues();
-            transform = newTransform;
-        }
     }
 }

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorHeldBagTyped.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorHeldBagTyped.cs
@@ -6,32 +6,30 @@ using Vintagestory.GameContent;
 
 namespace AttributeRenderingLibrary;
 
-public class CollectibleBehaviorHeldBagTyped : CollectibleBehaviorHeldBag
+public class CollectibleBehaviorHeldBagTyped(CollectibleObject collObj) : CollectibleBehaviorHeldBag(collObj)
 {
-    public Dictionary<string, int> quantitySlotsByType = new();
-    public Dictionary<string, string> slotBgColorByType = new();
-    public Dictionary<string, EnumItemStorageFlags> storageFlagsByType = new();
-
-    public CollectibleBehaviorHeldBagTyped(CollectibleObject collObj) : base(collObj) { }
+    public Dictionary<string, int> QuantitySlotsByType { get; protected set; }
+    public Dictionary<string, string> SlotBgColorByType { get; protected set; }
+    public Dictionary<string, EnumItemStorageFlags> StorageFlagsByType { get; protected set; }
 
     public override void Initialize(JsonObject properties)
     {
         base.Initialize(properties);
 
-        quantitySlotsByType = properties["quantitySlots"].AsObject<Dictionary<string, int>>();
-        slotBgColorByType = properties["slotBgColor"].AsObject<Dictionary<string, string>>();
-        storageFlagsByType = properties["storageFlags"].AsObject<Dictionary<string, int>>()?.ToDictionary(x => x.Key, x => (EnumItemStorageFlags)x.Value);
+        QuantitySlotsByType = properties["quantitySlots"].AsObject<Dictionary<string, int>>();
+        SlotBgColorByType = properties["slotBgColor"].AsObject<Dictionary<string, string>>();
+        StorageFlagsByType = properties["storageFlags"].AsObject<Dictionary<string, int>>()?.ToDictionary(x => x.Key, x => (EnumItemStorageFlags)x.Value);
     }
 
     public override int GetQuantitySlots(ItemStack bagstack)
     {
-        if (quantitySlotsByType == null || !quantitySlotsByType.Any())
+        if (QuantitySlotsByType == null || QuantitySlotsByType.Count == 0)
         {
             return base.GetQuantitySlots(bagstack);
         }
 
         Variants variants = Variants.FromStack(bagstack);
-        bool found = variants.FindByVariant(quantitySlotsByType, out int quantitySlots);
+        bool found = variants.FindByVariant(QuantitySlotsByType, out int quantitySlots);
 
         if (!found)
         {
@@ -42,13 +40,13 @@ public class CollectibleBehaviorHeldBagTyped : CollectibleBehaviorHeldBag
 
     public override string GetSlotBgColor(ItemStack bagstack)
     {
-        if (slotBgColorByType == null || !slotBgColorByType.Any())
+        if (SlotBgColorByType == null || SlotBgColorByType.Count == 0)
         {
             return base.GetSlotBgColor(bagstack);
         }
 
         Variants variants = Variants.FromStack(bagstack);
-        bool found = variants.FindByVariant(slotBgColorByType, out string slotBgColor);
+        bool found = variants.FindByVariant(SlotBgColorByType, out string slotBgColor);
 
         if (!found)
         {
@@ -61,13 +59,13 @@ public class CollectibleBehaviorHeldBagTyped : CollectibleBehaviorHeldBag
 
     public override EnumItemStorageFlags GetStorageFlags(ItemStack bagstack)
     {
-        if (storageFlagsByType == null || !storageFlagsByType.Any())
+        if (StorageFlagsByType == null || StorageFlagsByType.Count == 0)
         {
             return base.GetStorageFlags(bagstack);
         }
 
         Variants variants = Variants.FromStack(bagstack);
-        bool found = variants.FindByVariant(storageFlagsByType, out EnumItemStorageFlags storageFlags);
+        bool found = variants.FindByVariant(StorageFlagsByType, out EnumItemStorageFlags storageFlags);
 
         if (!found)
         {

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
@@ -10,26 +10,24 @@ using Vintagestory.GameContent;
 
 namespace AttributeRenderingLibrary;
 
-public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavior, IShapeTexturesFromAttributes, IContainedMeshSource, IContainedCustomName, IAttachableToEntity
+public class CollectibleBehaviorShapeTexturesFromAttributes(CollectibleObject collObj) : CollectibleBehavior(collObj), IShapeTexturesFromAttributes, IContainedMeshSource, IContainedCustomName, IAttachableToEntity
 {
-    public Dictionary<string, List<object>> NameByType { get; protected set; } = new();
-    public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
-    public Dictionary<string, List<object>> ContainedDescriptionByType { get; protected set; } = new();
+    public Dictionary<string, List<object>> NameByType { get; protected set; }
+    public Dictionary<string, List<object>> DescriptionByType { get; protected set; }
+    public Dictionary<string, List<object>> ContainedDescriptionByType { get; protected set; }
 
-    public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
-    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
+    public Dictionary<string, CompositeShape> shapeByType { get; protected set; }
+    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; }
 
     #region IAttachableToEntity
-    public Dictionary<string, OrderedDictionary<string, CompositeShape>> attachedShapeBySlotCodeByType = new();
-    public Dictionary<string, string> categoryCodeByType = new();
-    public Dictionary<string, string[]> disableElementsByType = new();
-    public Dictionary<string, string[]> keepElementsByType = new();
+    public Dictionary<string, OrderedDictionary<string, CompositeShape>> AttachedShapeBySlotCodeByType { get; protected set; }
+    public Dictionary<string, string> CategoryCodeByType { get; protected set; }
+    public Dictionary<string, string[]> DisableElementsByType { get; protected set; }
+    public Dictionary<string, string[]> KeepElementsByType { get; protected set; }
     private IAttachableToEntity iattr;
     #endregion
 
     private ICoreClientAPI clientApi;
-
-    public CollectibleBehaviorShapeTexturesFromAttributes(CollectibleObject collObj) : base(collObj) { }
 
     public override void OnLoaded(ICoreAPI api)
     {
@@ -50,10 +48,10 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
             shapeByType = properties["shape"].AsObject<Dictionary<string, CompositeShape>>();
             texturesByType = properties["textures"].AsObject<Dictionary<string, Dictionary<string, CompositeTexture>>>();
 
-            attachedShapeBySlotCodeByType = properties["STFA_attachableToEntity"]?["attachedShapeBySlotCode"].AsObject<Dictionary<string, OrderedDictionary<string, CompositeShape>>>();
-            categoryCodeByType = properties["STFA_attachableToEntity"]?["categoryCode"].AsObject<Dictionary<string, string>>();
-            disableElementsByType = properties["STFA_attachableToEntity"]?["disableElements"].AsObject<Dictionary<string, string[]>>();
-            keepElementsByType = properties["STFA_attachableToEntity"]?["keepElements"].AsObject<Dictionary<string, string[]>>();
+            AttachedShapeBySlotCodeByType = properties["STFA_attachableToEntity"]?["attachedShapeBySlotCode"].AsObject<Dictionary<string, OrderedDictionary<string, CompositeShape>>>();
+            CategoryCodeByType = properties["STFA_attachableToEntity"]?["categoryCode"].AsObject<Dictionary<string, string>>();
+            DisableElementsByType = properties["STFA_attachableToEntity"]?["disableElements"].AsObject<Dictionary<string, string[]>>();
+            KeepElementsByType = properties["STFA_attachableToEntity"]?["keepElements"].AsObject<Dictionary<string, string[]>>();
         }
     }
 
@@ -204,7 +202,7 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
             shape.Textures[textureCode] = texture.Baked.BakedName;
         }
 
-        Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType = new();
+        Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType = [];
 
         if (stack.Collectible.GetCollectibleInterface<IShapeTexturesFromAttributes>() is IShapeTexturesFromAttributes STFA)
         {
@@ -232,13 +230,13 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
 
     CompositeShape IAttachableToEntity.GetAttachedShape(ItemStack stack, string slotCode)
     {
-        if (attachedShapeBySlotCodeByType == null || attachedShapeBySlotCodeByType.Count == 0)
+        if (AttachedShapeBySlotCodeByType == null || AttachedShapeBySlotCodeByType.Count == 0)
         {
             return iattr?.GetAttachedShape(stack, slotCode);
         }
 
         Variants variants = Variants.FromStack(stack);
-        if (!variants.FindByVariant(attachedShapeBySlotCodeByType, out OrderedDictionary<string, CompositeShape> attachedShapeBySlotCode))
+        if (!variants.FindByVariant(AttachedShapeBySlotCodeByType, out OrderedDictionary<string, CompositeShape> attachedShapeBySlotCode))
         {
             return iattr?.GetAttachedShape(stack, slotCode);
         }
@@ -255,7 +253,7 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
                         return rcshape;
                     }
 
-                    List<CompositeShape> overlays = new();
+                    List<CompositeShape> overlays = [];
                     foreach (CompositeShape overlay in rcshape.Overlays)
                     {
                         if (clientApi.Assets.Exists(overlay.Base.Clone().CopyWithPathPrefixAndAppendixOnce("shapes/", ".json")))
@@ -274,37 +272,37 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
 
     string IAttachableToEntity.GetCategoryCode(ItemStack stack)
     {
-        if (categoryCodeByType == null || categoryCodeByType.Count == 0)
+        if (CategoryCodeByType == null || CategoryCodeByType.Count == 0)
         {
             return iattr?.GetCategoryCode(stack);
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(categoryCodeByType, out string categoryCode);
+        variants.FindByVariant(CategoryCodeByType, out string categoryCode);
         return categoryCode;
     }
 
     string[] IAttachableToEntity.GetDisableElements(ItemStack stack)
     {
-        if (disableElementsByType == null || disableElementsByType.Count == 0)
+        if (DisableElementsByType == null || DisableElementsByType.Count == 0)
         {
             return iattr?.GetDisableElements(stack);
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(disableElementsByType, out string[] disableElements);
+        variants.FindByVariant(DisableElementsByType, out string[] disableElements);
         return disableElements;
     }
 
     string[] IAttachableToEntity.GetKeepElements(ItemStack stack)
     {
-        if (keepElementsByType == null || keepElementsByType.Count == 0)
+        if (KeepElementsByType == null || KeepElementsByType.Count == 0)
         {
             return iattr?.GetKeepElements(stack);
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(keepElementsByType, out string[] keepElements);
+        variants.FindByVariant(KeepElementsByType, out string[] keepElements);
         return keepElements;
     }
 

--- a/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/CollectibleBehavior/CollectibleBehaviorShapeTexturesFromAttributes.cs
@@ -97,7 +97,16 @@ public class CollectibleBehaviorShapeTexturesFromAttributes : CollectibleBehavio
 
         ShapeOverlayHelper.BakeVariantTextures(clientApi, stexSource, variants, texturesByType, prefixedTextureCodes, overlayPrefix);
 
-        clientApi.Tesselator.TesselateShape("ShapeTexturesFromAttributes behavior", shape, out mesh, stexSource, quantityElements: rcshape.QuantityElements, selectiveElements: rcshape.SelectiveElements);
+        TesselationMetaData meta = new TesselationMetaData
+        {
+            QuantityElements = rcshape.QuantityElements,
+            SelectiveElements = rcshape.SelectiveElements,
+            IgnoreElements = rcshape.IgnoreElements,
+            TexSource = stexSource,
+            TypeForLogging = "ShapeTexturesFromAttributes item behavior"
+        };
+
+        clientApi.Tesselator.TesselateShape(meta, shape, out mesh);
         return mesh;
     }
 

--- a/AttributeRenderingLibrary/HarmonyPatches/GetDropsForHandbookPatch.cs
+++ b/AttributeRenderingLibrary/HarmonyPatches/GetDropsForHandbookPatch.cs
@@ -25,7 +25,7 @@ public static class GetDropsForHandbookPatch
             for (int i = 0; i < unresolvedDrops.Length; i++)
             {
                 BlockDropItemStack dstack = variants.ReplacePlaceholders(unresolvedDrops[i].Clone());
-                if (dstack.Resolve(forPlayer.Entity.World, "", ""))
+                if (dstack.Resolve(forPlayer.Entity.World, "AttributeRenderingLibrary.BlockShapeTexturesFromAttributes", dstack.Code))
                 {
                     resolvedDrops.Add(dstack);
                 }

--- a/AttributeRenderingLibrary/HarmonyPatches/GetDropsForHandbookPatch.cs
+++ b/AttributeRenderingLibrary/HarmonyPatches/GetDropsForHandbookPatch.cs
@@ -1,6 +1,6 @@
 ﻿
 using HarmonyLib;
-using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 using Vintagestory.API.Common;
 
 namespace AttributeRenderingLibrary;
@@ -8,22 +8,32 @@ namespace AttributeRenderingLibrary;
 [HarmonyPatch(typeof(Block), nameof(Block.GetDropsForHandbook))]
 public static class GetDropsForHandbookPatch
 {
-    [HarmonyReversePatch(HarmonyReversePatchType.Original)]
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static BlockDropItemStack[] Base(this Block instance, ItemStack handbookStack, IPlayer forPlayer) => default;
-
-    [HarmonyPrefix]
-    public static bool Prefix(Block __instance, ref BlockDropItemStack[] __result, ItemStack handbookStack, IPlayer forPlayer)
+    [HarmonyPostfix]
+    public static void Postfix(Block __instance, ref BlockDropItemStack[] __result, ItemStack handbookStack, IPlayer forPlayer)
     {
-        if (handbookStack?.Collectible?.GetCollectibleInterface<IShapeTexturesFromAttributes>() is not IShapeTexturesFromAttributes shapeTexturesFromAttributes)
+        if (handbookStack?.Collectible?.GetCollectibleInterface<IBlockShapeTexturesFromAttributes>() is not IBlockShapeTexturesFromAttributes shapeTexturesFromAttributes)
         {
-            return true;
+            return;
         }
 
-        BlockDropItemStack[] drops = Base(__instance, handbookStack, forPlayer) ?? [];
-        drops[0] = drops[0].Clone();
-        drops[0].ResolvedItemstack.SetFrom(handbookStack);
-        __result = drops;
-        return false;
+        Variants variants = Variants.FromStack(handbookStack);
+        if (variants.FindByVariant(shapeTexturesFromAttributes.DropsByType, out BlockDropItemStack[] unresolvedDrops)
+            && unresolvedDrops != null
+            && unresolvedDrops.Length > 0)
+        {
+            List<BlockDropItemStack> resolvedDrops = new(unresolvedDrops.Length);
+            for (int i = 0; i < unresolvedDrops.Length; i++)
+            {
+                BlockDropItemStack dstack = variants.ReplacePlaceholders(unresolvedDrops[i].Clone());
+                if (dstack.Resolve(forPlayer.Entity.World, "", ""))
+                {
+                    resolvedDrops.Add(dstack);
+                }
+            }
+            __result = resolvedDrops.ToArray();
+            return;
+        }
+
+        __result = [new BlockDropItemStack(handbookStack)];
     }
 }

--- a/AttributeRenderingLibrary/Item/ItemShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/Item/ItemShapeTexturesFromAttributes.cs
@@ -94,7 +94,16 @@ public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttribute
 
         ShapeOverlayHelper.BakeVariantTextures(clientApi, stexSource, variants, texturesByType, prefixedTextureCodes, overlayPrefix);
 
-        clientApi.Tesselator.TesselateShape("ShapeTexturesFromAttributes item", shape, out mesh, stexSource, quantityElements: rcshape.QuantityElements, selectiveElements: rcshape.SelectiveElements);
+        TesselationMetaData meta = new TesselationMetaData
+        {
+            QuantityElements = rcshape.QuantityElements,
+            SelectiveElements = rcshape.SelectiveElements,
+            IgnoreElements = rcshape.IgnoreElements,
+            TexSource = stexSource,
+            TypeForLogging = "ShapeTexturesFromAttributes item"
+        };
+
+        clientApi.Tesselator.TesselateShape(meta, shape, out mesh);
         return mesh;
     }
 

--- a/AttributeRenderingLibrary/Item/ItemShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/Item/ItemShapeTexturesFromAttributes.cs
@@ -12,18 +12,18 @@ namespace AttributeRenderingLibrary;
 
 public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttributes, IContainedMeshSource, IContainedCustomName, IAttachableToEntity
 {
-    public Dictionary<string, List<object>> NameByType { get; protected set; } = new();
-    public Dictionary<string, List<object>> DescriptionByType { get; protected set; } = new();
-    public Dictionary<string, List<object>> ContainedDescriptionByType { get; protected set; } = new();
+    public Dictionary<string, List<object>> NameByType { get; protected set; }
+    public Dictionary<string, List<object>> DescriptionByType { get; protected set; }
+    public Dictionary<string, List<object>> ContainedDescriptionByType { get; protected set; }
 
-    public Dictionary<string, CompositeShape> shapeByType { get; protected set; } = new();
-    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; } = new();
+    public Dictionary<string, CompositeShape> shapeByType { get; protected set; }
+    public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; protected set; }
 
     #region IAttachableToEntity
-    public Dictionary<string, OrderedDictionary<string, CompositeShape>> attachedShapeBySlotCodeByType = new();
-    public Dictionary<string, string> categoryCodeByType = new();
-    public Dictionary<string, string[]> disableElementsByType = new();
-    public Dictionary<string, string[]> keepElementsByType = new();
+    public Dictionary<string, OrderedDictionary<string, CompositeShape>> AttachedShapeBySlotCodeByType { get; protected set; }
+    public Dictionary<string, string> CategoryCodeByType { get; protected set; }
+    public Dictionary<string, string[]> DisableElementsByType { get; protected set; }
+    public Dictionary<string, string[]> KeepElementsByType { get; protected set; }
     private IAttachableToEntity iattr;
     #endregion
 
@@ -53,10 +53,10 @@ public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttribute
             shapeByType = Attributes["shape"].AsObject<Dictionary<string, CompositeShape>>();
             texturesByType = Attributes["textures"].AsObject<Dictionary<string, Dictionary<string, CompositeTexture>>>();
 
-            attachedShapeBySlotCodeByType = Attributes["STFA_attachableToEntity"]?["attachedShapeBySlotCode"].AsObject<Dictionary<string, OrderedDictionary<string, CompositeShape>>>();
-            categoryCodeByType = Attributes["STFA_attachableToEntity"]?["categoryCode"].AsObject<Dictionary<string, string>>();
-            disableElementsByType = Attributes["STFA_attachableToEntity"]?["disableElements"].AsObject<Dictionary<string, string[]>>();
-            keepElementsByType = Attributes["STFA_attachableToEntity"]?["keepElements"].AsObject<Dictionary<string, string[]>>();
+            AttachedShapeBySlotCodeByType = Attributes["STFA_attachableToEntity"]?["attachedShapeBySlotCode"].AsObject<Dictionary<string, OrderedDictionary<string, CompositeShape>>>();
+            CategoryCodeByType = Attributes["STFA_attachableToEntity"]?["categoryCode"].AsObject<Dictionary<string, string>>();
+            DisableElementsByType = Attributes["STFA_attachableToEntity"]?["disableElements"].AsObject<Dictionary<string, string[]>>();
+            KeepElementsByType = Attributes["STFA_attachableToEntity"]?["keepElements"].AsObject<Dictionary<string, string[]>>();
         }
     }
 
@@ -201,7 +201,7 @@ public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttribute
             shape.Textures[textureCode] = texture.Baked.BakedName;
         }
 
-        Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType = new();
+        Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType = [];
 
         if (stack.Collectible.GetCollectibleInterface<IShapeTexturesFromAttributes>() is IShapeTexturesFromAttributes STFA)
         {
@@ -229,13 +229,13 @@ public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttribute
 
     CompositeShape IAttachableToEntity.GetAttachedShape(ItemStack stack, string slotCode)
     {
-        if (attachedShapeBySlotCodeByType == null || attachedShapeBySlotCodeByType.Count == 0)
+        if (AttachedShapeBySlotCodeByType == null || AttachedShapeBySlotCodeByType.Count == 0)
         {
             return iattr?.GetAttachedShape(stack, slotCode);
         }
 
         Variants variants = Variants.FromStack(stack);
-        if (!variants.FindByVariant(attachedShapeBySlotCodeByType, out OrderedDictionary<string, CompositeShape> attachedShapeBySlotCode))
+        if (!variants.FindByVariant(AttachedShapeBySlotCodeByType, out OrderedDictionary<string, CompositeShape> attachedShapeBySlotCode))
         {
             return iattr?.GetAttachedShape(stack, slotCode);
         }
@@ -252,7 +252,7 @@ public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttribute
                         return rcshape;
                     }
 
-                    List<CompositeShape> overlays = new();
+                    List<CompositeShape> overlays = [];
                     foreach (CompositeShape overlay in rcshape.Overlays)
                     {
                         if (api.Assets.Exists(overlay.Base.Clone().CopyWithPathPrefixAndAppendixOnce("shapes/", ".json")))
@@ -271,37 +271,37 @@ public class ItemShapeTexturesFromAttributes : Item, IShapeTexturesFromAttribute
 
     string IAttachableToEntity.GetCategoryCode(ItemStack stack)
     {
-        if (categoryCodeByType == null || categoryCodeByType.Count == 0)
+        if (CategoryCodeByType == null || CategoryCodeByType.Count == 0)
         {
             return iattr?.GetCategoryCode(stack);
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(categoryCodeByType, out string categoryCode);
+        variants.FindByVariant(CategoryCodeByType, out string categoryCode);
         return categoryCode;
     }
 
     string[] IAttachableToEntity.GetDisableElements(ItemStack stack)
     {
-        if (disableElementsByType == null || disableElementsByType.Count == 0)
+        if (DisableElementsByType == null || DisableElementsByType.Count == 0)
         {
             return iattr?.GetDisableElements(stack);
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(disableElementsByType, out string[] disableElements);
+        variants.FindByVariant(DisableElementsByType, out string[] disableElements);
         return disableElements;
     }
 
     string[] IAttachableToEntity.GetKeepElements(ItemStack stack)
     {
-        if (keepElementsByType == null || keepElementsByType.Count == 0)
+        if (KeepElementsByType == null || KeepElementsByType.Count == 0)
         {
             return iattr?.GetKeepElements(stack);
         }
 
         Variants variants = Variants.FromStack(stack);
-        variants.FindByVariant(keepElementsByType, out string[] keepElements);
+        variants.FindByVariant(KeepElementsByType, out string[] keepElements);
         return keepElements;
     }
 

--- a/AttributeRenderingLibrary/Utility/CuboidExtensions.cs
+++ b/AttributeRenderingLibrary/Utility/CuboidExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+
+namespace AttributeRenderingLibrary;
+
+public static class CuboidExtensions
+{
+    public static Cuboidf[] ToCuboidf(this RotatableCube[] cubes)
+    {
+        Cuboidf[] newCubes = new Cuboidf[cubes.Length];
+        for (int i = 0; i < cubes.Length; i++)
+        {
+            newCubes[i] = cubes[i].RotatedCopy();
+        }
+        return newCubes;
+    }
+}

--- a/AttributeRenderingLibrary/Utility/IShapeTexturesFromAttributes.cs
+++ b/AttributeRenderingLibrary/Utility/IShapeTexturesFromAttributes.cs
@@ -9,3 +9,8 @@ public interface IShapeTexturesFromAttributes
     public Dictionary<string, CompositeShape> shapeByType { get; }
     public Dictionary<string, Dictionary<string, CompositeTexture>> texturesByType { get; }
 }
+
+public interface IBlockShapeTexturesFromAttributes : IShapeTexturesFromAttributes
+{
+    public Dictionary<string, BlockDropItemStack[]> DropsByType { get; }
+}

--- a/AttributeRenderingLibrary/Utility/Transforms.cs
+++ b/AttributeRenderingLibrary/Utility/Transforms.cs
@@ -5,8 +5,8 @@ namespace AttributeRenderingLibrary;
 
 public class Transforms
 {
-    public Dictionary<string, ModelTransform> GuiTransform { get; set; } = new();
-    public Dictionary<string, ModelTransform> TpHandTransform { get; set; } = new();
-    public Dictionary<string, ModelTransform> TpOffHandTransform { get; set; } = new();
-    public Dictionary<string, ModelTransform> GroundTransform { get; set; } = new();
+    public Dictionary<string, ModelTransform> GuiTransform { get; set; }
+    public Dictionary<string, ModelTransform> TpHandTransform { get; set; }
+    public Dictionary<string, ModelTransform> TpOffHandTransform { get; set; }
+    public Dictionary<string, ModelTransform> GroundTransform { get; set; }
 }

--- a/AttributeRenderingLibrary/Utility/VariantExtensions.cs
+++ b/AttributeRenderingLibrary/Utility/VariantExtensions.cs
@@ -22,7 +22,7 @@ public static class VariantExtensions
     {
         result = default;
 
-        if (variants == null || inDictionary == null || !inDictionary.Any())
+        if (variants == null || inDictionary == null || inDictionary.Count == 0)
         {
             return false;
         }
@@ -30,7 +30,7 @@ public static class VariantExtensions
         List<string> variantAsStringArray = variants.GetAsStringArray();
         foreach ((string key, T value) in inDictionary)
         {
-            string[] keys = key.Contains("::") ? key.Split("::") : new[] { key };
+            string[] keys = key.Contains("::") ? key.Split("::") : [key];
             if (keys.All(k => variantAsStringArray.Any(v => WildcardUtil.Match(k, v))))
             {
                 result = value;

--- a/AttributeRenderingLibrary/Utility/Variants.cs
+++ b/AttributeRenderingLibrary/Utility/Variants.cs
@@ -20,7 +20,7 @@ public class Variants
     protected Dictionary<string, string> Elements { get; set; } = new();
 
     public int Count => Elements.Count;
-    public bool Any => Elements.Any();
+    public bool Any => Elements.Count != 0;
 
     public List<string> GetAsStringArray()
     {
@@ -209,7 +209,7 @@ public class Variants
     public override string ToString()
     {
         StringBuilder result = new StringBuilder();
-        if (Elements.Any())
+        if (Elements.Count != 0)
         {
             result.Append(string.Join('-', Elements.Select(x => $"{x.Key}-{x.Value}")));
         }

--- a/AttributeRenderingLibrary/Utility/Variants.cs
+++ b/AttributeRenderingLibrary/Utility/Variants.cs
@@ -192,6 +192,20 @@ public class Variants
         return jstack;
     }
 
+    public BlockDropItemStack ReplacePlaceholders(BlockDropItemStack bdstack)
+    {
+        bdstack.Code = ReplacePlaceholders(bdstack.Code);
+
+        if (bdstack.Attributes != null)
+        {
+            foreach ((string key, string value) in Elements)
+            {
+                bdstack.Attributes.FillPlaceHolder(key, value);
+            }
+        }
+        return bdstack;
+    }
+
     public override string ToString()
     {
         StringBuilder result = new StringBuilder();


### PR DESCRIPTION
- Feature: Implemented more methods for block behavior:
  - collision and selection boxes
  - drops
  - shapeInventory
- Feature: Implemented ignoreElements for shapes 
- Fixed: Block mesh not redrawing on changing variants
- Fixed: Blocks with attributes system that don't set canChisel can be destroyed by chiseling (canChisel is now forcefully set to false for such blocks)
- Fixed: Blocks not displaying drops properly in handbook
