### PR TITLE
Prevent universal patches from being applied twice in singleplayer.

### DIFF
--- a/AttributeRenderingLibrary/Systems/Core.cs
+++ b/AttributeRenderingLibrary/Systems/Core.cs
@@ -1,4 +1,5 @@
-﻿using AttributeRenderingLibrary.Utility.Creativestacks;
+﻿using AttributeRenderingLibrary.HarmonyPatches;
+using AttributeRenderingLibrary.Utility.Creativestacks;
 using HarmonyLib;
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
@@ -15,7 +16,10 @@ public class Core : ModSystem
     {
         Api = api;
 
-        HarmonyInstance.PatchAllUncategorized();
+        if (!Harmony.HasAnyPatches(HarmonyInstance.Id))
+        {
+            HarmonyInstance.PatchAllUncategorized();
+        }
 
         if (api.Side.IsServer())
         {


### PR DESCRIPTION
Harmony does not prevent applying a patch twice, so you should always ensure it only runs once yourself.