### PR TITLE
perf(HarmonyPatches.Handbook): skip empty searches in FilterItems

### DIFF
--- a/AttributeRenderingLibrary/HarmonyPatches/Handbook/GuiDialogHandbook_FilterItems_Patch.cs
+++ b/AttributeRenderingLibrary/HarmonyPatches/Handbook/GuiDialogHandbook_FilterItems_Patch.cs
@@ -33,44 +33,50 @@ public static class GuiDialogHandbook_FilterItems_Patch
 
             List<WeightedHandbookPage> weightedPages = new List<WeightedHandbookPage>();
 
-            foreach (var page in ___allHandbookPages)
+            if (searchText.Length == 0)
             {
-                #region Handbook search include and exclude logic
-                if (page is GuiHandbookItemStackPage { Stack: not null } stackPage)
+                ___shownHandbookPages.AddRange(___allHandbookPages);
+            }
+            else
+            {
+                // TODO: use only one loop for selecting, sorting, and adding;
+                // TODO: if more than N items, break list into chunk and operate on each chunk with Parallel.ForEach to separate Lists; Aggregate results to single list. Or iterate through each them to add their items to ___shownHandbookPages
+                foreach (var page in ___allHandbookPages)
                 {
-                    if (stackPage.Stack.Collectible?.GetCollectibleInterface<IHandbookARL>() is { } arl && arl.ExcludeFromHandbookSearch(stackPage.Stack))
+                    #region Handbook search include and exclude logic
+                    if (page is GuiHandbookItemStackPage { Stack: not null } stackPage)
+                    {
+                        if (stackPage.Stack.Collectible?.GetCollectibleInterface<IHandbookARL>() is { } arl && arl.ExcludeFromHandbookSearch(stackPage.Stack))
+                        {
+                            continue;
+                        }
+                    }
+                    #endregion
+
+                    if ((___currentCatgoryCode != null && page.CategoryCode != ___currentCatgoryCode) || page.IsDuplicate)
                     {
                         continue;
                     }
-                }
-                #endregion
 
-                if ((___currentCatgoryCode != null && page.CategoryCode != ___currentCatgoryCode) || page.IsDuplicate)
-                {
-                    continue;
-                }
+                    PageText pageText = page.GetPageText();
+                    int titleMatches = CountMatches(__instance, pageText.Title ?? "", regex);
+                    int strictTitleMatches = CountMatches(__instance, pageText.Title ?? "", strictRegex);
+                    int textMatches = CountMatches(__instance, pageText.Text ?? "", regex);
 
-                PageText pageText = page.GetPageText();
-                int titleMatches = CountMatches(__instance, pageText.Title ?? "", regex);
-                int strictTitleMatches = CountMatches(__instance, pageText.Title ?? "", strictRegex);
-                int textMatches = CountMatches(__instance, pageText.Text ?? "", regex);
-
-                if (titleMatches > 0 || textMatches > 0)
-                {
-                    weightedPages.Add(new WeightedHandbookPage
+                    if (titleMatches > 0 || textMatches > 0)
                     {
-                        Page = page,
-                        TitleMatches = titleMatches,
-                        StrictTitleMatches = strictTitleMatches,
-                        TitleLength = pageText.Title?.Length ?? 0,
-                        TextMatches = textMatches,
-                        SearchWeight = 1f + page.SearchWeightOffset
-                    });
+                        weightedPages.Add(new WeightedHandbookPage
+                        {
+                            Page = page,
+                            TitleMatches = titleMatches,
+                            StrictTitleMatches = strictTitleMatches,
+                            TitleLength = pageText.Title?.Length ?? 0,
+                            TextMatches = textMatches,
+                            SearchWeight = 1f + page.SearchWeightOffset
+                        });
+                    }
                 }
-            }
 
-            if (searchText.Length > 0)
-            {
                 weightedPages.Sort((a, b) =>
                 {
                     int strictSort = b.StrictTitleMatches - a.StrictTitleMatches;
@@ -87,11 +93,11 @@ public static class GuiDialogHandbook_FilterItems_Patch
 
                     return b.TextMatches - a.TextMatches;
                 });
-            }
 
-            foreach (var p in weightedPages)
-            {
-                ___shownHandbookPages.Add(p.Page);
+                foreach (var p in weightedPages)
+                {
+                    ___shownHandbookPages.Add(p.Page);
+                }
             }
         }
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Condition="Exists('./Directory.Build.props.user')"
+    Project="./Directory.Build.props.user" />
+  <PropertyGroup>
+    <VINTAGE_STORY>$(VINTAGE_STORY.Trim())</VINTAGE_STORY>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Based on Panduh's explanation in their [HoR Performance Optimizer mod's v1.0.1 release notes](https://mods.vintagestory.at/horperfopt#:~:text=Handbook%20open%20lag%20fixed%20%28~500ms%20to%20near%2Dinstant%29). As mentioned in the TODO tasks, there's room for optimization when searching the handbook aside from indexed caches.

Solves #32