### PR TITLE
Fix for Clone function

### DIFF
--- a/AttributeRenderingLibrary/Utility/Variants.cs
+++ b/AttributeRenderingLibrary/Utility/Variants.cs
@@ -292,6 +292,6 @@ public class Variants
 
     public Variants Clone()
     {
-        return new() { Elements = Elements };
+        return new() { Elements = new SortedDictionary<string, string>(Elements) };
     }
 }


### PR DESCRIPTION
I figured that if the crash was happening [even with checks](https://github.com/Craluminum-Mods/AttributeRenderingLibrary/blob/636e027616a075b4664f37de821f0a039fd13f20/AttributeRenderingLibrary/Utility/VariantExtensions.cs#L27), the error was occurring during the check, so I dug deeper in variants.Count. I found a bug with the Clone() function. If you think you're working with a copy, but in fact you're working with the real list, there will definitely be bugs. I haven't tested it, but this should solve the null pointer issue.
```
System.NullReferenceException: Object reference not set to an instance of an object.
at AttributeRenderingLibrary.VariantExtensions.FindByVariant[T](Variants variants, Dictionary`2 inDictionary, T& result)
at AttributeRenderingLibrary.BlockBehaviorShapeTexturesFromAttributes.GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, Boolean withDebugInfo) in C:\Users\dana_\Source\Repos\AttributeRenderingLibrary\AttributeRenderingLibrary\BlockBehavior\BlockBehaviorShapeTexturesFromAttributes.cs:line 880
at Vintagestory.API.Common.CollectibleObject.GetHeldItemInfo_Patch6(CollectibleObject this, ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, Boolean withDebugInfo)
at Vintagestory.API.Common.Block.GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, Boolean withDebugInfo) in VintagestoryApi\Common\Collectible\Block\Block.cs:line 2401
at Vintagestory.GameContent.GuiHandbookItemStackPage..ctor(ICoreClientAPI capi, ItemStack stack) in VSSurvivalMod\Systems\Handbook\Gui\GuiHandbookItemStackPage.cs:line 35
at Vintagestory.GameContent.ModSystemSurvivalHandbook.onCreatePagesAsync() in VSSurvivalMod\Systems\Handbook\SurvivalHandbook.cs:line 122
at Vintagestory.GameContent.GuiDialogHandbook.LoadPages_Async() in VSSurvivalMod\Systems\Handbook\Gui\GuiDialogHandbook.cs:line 434
at Vintagestory.API.Common.TyronThreadPool.<>c__DisplayClass11_0.<QueueTask>b__0(Object _) in VintagestoryApi\Common\TyronThreadPool.cs:line 119
at System.Threading.ThreadPoolWorkQueue.Dispatch()
at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
at System.Threading.Thread.StartCallback()
```