### PR TITLE
FromStack Null safety

### DIFF
--- a/AttributeRenderingLibrary/Utility/Variants.cs
+++ b/AttributeRenderingLibrary/Utility/Variants.cs
@@ -125,6 +125,11 @@ public class Variants
 
     public static Variants FromStack(ItemStack stack)
     {
+        if (stack?.Attributes == null)
+        {
+            return new Variants();
+        }
+    
         return FromTreeAttribute(stack.Attributes);
     }
 


### PR DESCRIPTION
[Potential bug.](https://github.com/Craluminum-Mods/AttributeRenderingLibrary/blob/636e027616a075b4664f37de821f0a039fd13f20/AttributeRenderingLibrary/BlockBehavior/BlockBehaviorShapeTexturesFromAttributes.cs#L877) It may be that null will never appear there, but still, when calling it, we indicate that it can be there.