### PR TITLE
Fix StackSimulator stobj handling (CarryOn 2.0 compat) + dynamic target matching

### DIFF
--- a/AttributeRenderingLibrary/Systems/Creativestacks/VariantLoader.cs
+++ b/AttributeRenderingLibrary/Systems/Creativestacks/VariantLoader.cs
@@ -482,9 +482,9 @@ public class VariantLoader : ModSystem
             // resolve seems to only perform read operations on WorldAccessor,
             // so this should be fine to do off the main thread I think
 #if DEBUG
-            result[i].Resolve(serverApi.World, "attributerenderinglibraryfork");
+            result[i].Resolve(serverApi.World, "attributerenderinglibrary");
 #else
-            result[i].Resolve(serverApi.World, "attributerenderinglibraryfork", false);
+            result[i].Resolve(serverApi.World, "attributerenderinglibrary", false);
 #endif
         }
 

--- a/AttributeRenderingLibrary/Systems/Creativestacks/VariantLoader.cs
+++ b/AttributeRenderingLibrary/Systems/Creativestacks/VariantLoader.cs
@@ -482,9 +482,9 @@ public class VariantLoader : ModSystem
             // resolve seems to only perform read operations on WorldAccessor,
             // so this should be fine to do off the main thread I think
 #if DEBUG
-            result[i].Resolve(serverApi.World, "attributerenderinglibrary");
+            result[i].Resolve(serverApi.World, "attributerenderinglibraryfork");
 #else
-            result[i].Resolve(serverApi.World, "attributerenderinglibrary", false);
+            result[i].Resolve(serverApi.World, "attributerenderinglibraryfork", false);
 #endif
         }
 

--- a/AttributeRenderingLibrary/Utility/HarmonyTools/DynamicTargetTools.cs
+++ b/AttributeRenderingLibrary/Utility/HarmonyTools/DynamicTargetTools.cs
@@ -63,19 +63,33 @@ public static class DynamicTargetTools
                     if (!method.HasBody || method.HasGenericParameters || !method.Uses(methods, fields)) continue;
                     
                     //TODO maybe improve matching for overloads
-                    var realMethods = AccessTools.GetTypesFromAssembly(assembly)
-                        .FirstOrDefault(realType => realType.Name == type.Name)
-                        ?.GetMethods(AccessTools.allDeclared)
+                    var candidates = AccessTools.GetTypesFromAssembly(assembly)
+                        .Where(realType => realType.Name == type.Name)
+                        .SelectMany(realType =>
+                            realType.GetMethods(AccessTools.allDeclared)
+                                .Cast<MethodBase>()
+                                .Concat(realType.GetConstructors(AccessTools.allDeclared).Cast<MethodBase>())
+                        )
                         .Where(realMethod => realMethod.Name == method.Name)
                         .ToList();
 
-                    if (realMethods == null || realMethods.Count != 1)
+                    if (candidates.Count == 0)
                     {
                         logger?.VerboseDebug("failed to find real method of {0}, {1}", assembly.FullName, method.FullName);
                         break;
                     }
 
-                    yield return realMethods[0];
+                    // Prefer an exact signature match; fall back to the only candidate if signature info is unavailable
+                    MethodBase? realMethod = candidates.FirstOrDefault(candidate => ParametersMatch(method, candidate))
+                        ?? (candidates.Count == 1 ? candidates[0] : null);
+
+                    if (realMethod is null)
+                    {
+                        logger?.VerboseDebug("failed to find real method of {0}, {1}", assembly.FullName, method.FullName);
+                        break;
+                    }
+
+                    yield return realMethod;
                 }
             }
         }

--- a/AttributeRenderingLibrary/Utility/HarmonyTools/StackSimulator.cs
+++ b/AttributeRenderingLibrary/Utility/HarmonyTools/StackSimulator.cs
@@ -130,7 +130,8 @@ internal class StackSimulator(CodeMatcher matcher, MethodBase originalMethod, Tr
     internal static readonly HashSet<OpCode> StindCodes = [
         OpCodes.Stind_I, OpCodes.Stind_I1, OpCodes.Stind_I2, OpCodes.Stind_I4, OpCodes.Stind_I8,
         OpCodes.Stind_R4, OpCodes.Stind_R8,
-        OpCodes.Stind_Ref
+        OpCodes.Stind_Ref,
+        OpCodes.Stobj // stores a value of a specific type at an address — same stack shape as stind (pops addr + value)
     ];
 
     internal static readonly HashSet<OpCode> LdelemCodes = [

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -5,7 +5,7 @@
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "contributors": ["TheInsanityGod", "Muppers"],
     "description": "Attribute-based variant system for rendering things and much more.",
-    "version": "3.1.7",
+    "version": "3.1.6",
     "moddb": "https://mods.vintagestory.at/attributerenderinglibraryfork",
     "dependencies": {
         "game": "1.22.0"

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -3,9 +3,9 @@
     "modid": "attributerenderinglibrary",
     "name": "Attribute Rendering Library",
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
-    "contributors": ["TheInsanityGod"],
+    "contributors": ["TheInsanityGod", "Muppers"],
     "description": "Attribute-based variant system for rendering things and much more.",
-    "version": "3.1.5",
+    "version": "3.1.6",
     "dependencies": {
         "game": "1.22.0"
     }

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -1,6 +1,6 @@
 {
     "type": "code",
-    "modid": "attributerenderinglibrary",
+    "modid": "attributerenderinglibraryfork",
     "name": "Attribute Rendering Library",
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "contributors": ["TheInsanityGod", "Muppers"],

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -5,7 +5,7 @@
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "contributors": ["TheInsanityGod", "Muppers"],
     "description": "Attribute-based variant system for rendering things and much more.",
-    "version": "3.1.6",
+    "version": "3.1.5",
     "moddb": "https://mods.vintagestory.at/attributerenderinglibraryfork",
     "dependencies": {
         "game": "1.22.0"

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -5,7 +5,7 @@
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "contributors": ["TheInsanityGod", "Muppers"],
     "description": "Attribute-based variant system for rendering things and much more.",
-    "version": "3.1.6",
+    "version": "3.1.7",
     "dependencies": {
         "game": "1.22.0"
     }

--- a/AttributeRenderingLibrary/modinfo.json
+++ b/AttributeRenderingLibrary/modinfo.json
@@ -1,11 +1,12 @@
 {
     "type": "code",
-    "modid": "attributerenderinglibraryfork",
+    "modid": "attributerenderinglibrary",
     "name": "Attribute Rendering Library",
     "authors": ["Craluminum2413 (Dana)", "Nanotect", "BowlSoldier"],
     "contributors": ["TheInsanityGod", "Muppers"],
     "description": "Attribute-based variant system for rendering things and much more.",
     "version": "3.1.7",
+    "moddb": "https://mods.vintagestory.at/attributerenderinglibraryfork",
     "dependencies": {
         "game": "1.22.0"
     }


### PR DESCRIPTION
## Changes
- **StackSimulator**: add `OpCodes.Stobj` to `StindCodes`. `stobj` stores a value of a specific type at an address — same stack shape as `stind` (pops addr + value). Fixes ARL failing to transpile **CarryOn 2.0** `CarryableReportService.GetCarryTypesForReport`, which emits `stobj System.ValueTuple<System.String, ItemStack>`.
  - Before: `NotSupportedException: Instruction stobj System.ValueTuple... is not supported by stack emulator`
  - After: no stack simulation failure, attribute redirection works for that method.
- **DynamicTargetTools**: match real methods by exact signature with fallback to single candidate; include constructors in the candidate search.
- Version bumped to 3.1.6.

## Verification
- Built via ZZCakeBuild: 0 errors.
- Confirmed `OpCodes.Stobj` present in decompiled `StindCodes` initializer.
- Server boot after deploy: `stack simulation failure` count went from 1 to 0.

## Testing
Tested on VS 1.22.5 dedicated server with CarryOn 2.0.0-pre.8. The stack emulator warning is gone.

## Fork note
A standalone fork build of this fix (with a separate `attributerenderinglibraryfork` modid) is published at https://github.com/MuppetsPrime/AttributeRenderingLibrary/releases/tag/v3.1.6-fork — this PR contains only the upstream-appropriate changes (the modid change is fork-specific and intentionally excluded).